### PR TITLE
PP-148 make docker CMD wait for postgres to be available before running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM java:8-jre
+
+ENV DEBIAN_FRONTEND noninteractive
+CMD apt-get update && apt-get -y install netcat
+
 ENV JAVA_HOME /usr/lib/jvm/java-8-*/
 ENV PORT 8080
 ENV ADMIN_PORT 8081
@@ -9,4 +13,4 @@ WORKDIR /app
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 
-CMD sleep 2 && java -jar *-allinone.jar db migrate *.yaml && java -jar *-allinone.jar server *.yaml
+CMD until nc -zv postgres 5432; do sleep 1; done && java -jar *-allinone.jar db migrate *.yaml && java -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
The endtoend tests are randomly failing due to postgres not being available
at the time DB migrations start
