### PR TITLE
PP-101 Fix env var interpolation in env.sh & redirect.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -6,4 +6,4 @@ then
   source $ENV_FILE
   set +a  
 fi
-$@
+eval "$@"

--- a/redirect.sh
+++ b/redirect.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 cd ${0%/*}
 case "$1" in
-  "stop")
-    echo "Stopping redirector..."
+  'stop')
+    echo 'Stopping redirector...'
     docker kill pay-publicauth-redir && docker rm -f pay-publicauth-redir
     ;;
-  "start")
-    echo "Starting redirector..."
-    ./env.sh "docker run -d --name pay-publicauth-redir --net host -e IN_PORT=$PORT -e OUT_PORT=$PORT -e OUT_IP=192.168.99.1 govukpay/devhelper"
+  'start')
+    echo 'Starting redirector...'
+    ./env.sh 'docker run -d --name pay-publicauth-redir --net host -e IN_PORT=$PORT -e OUT_PORT=$PORT -e OUT_IP=192.168.99.1 govukpay/devhelper'
     ;;
   *)
-    echo "Usage: ./redirect.sh [start|stop]"
+    echo 'Usage: ./redirect.sh [start|stop]'
     ;;
 esac


### PR DESCRIPTION
Somehow bad use of single/double quotes got through the review process, but doesn't actually work.
Use eval and quotes appropriately to get $PORT passed in to the redirector correctly.
