### PR TITLE
PP-548 upgrade govukpay/postgres image version

### DIFF
--- a/src/test/java/uk/gov/pay/publicauth/utils/PostgresContainer.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/PostgresContainer.java
@@ -37,7 +37,7 @@ public class PostgresContainer {
     public static final String DB_PASSWORD = "mysecretpassword";
     public static final String DB_USERNAME = "postgres";
     public static final int DB_TIMEOUT_SEC = 15;
-    public static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.4.4";
+    public static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:1.0";
     public static final String INTERNAL_PORT = "5432";
 
     public PostgresContainer(DockerClient docker, String host) throws DockerException, InterruptedException, IOException, ClassNotFoundException {


### PR DESCRIPTION
As part of PP-548 a new databsase was introduced for selfservice and the default postgres image we have been using is upgraded to govukpay specific versioning.
