### PR TITLE
PP-182 Switch to DB_HOST from DB_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ hs_err_pid*
 target
 
 bin
+
+.DS_Store

--- a/src/main/java/uk/gov/pay/publicauth/util/TrustStoreLoader.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/TrustStoreLoader.java
@@ -1,0 +1,85 @@
+package uk.gov.pay.publicauth.util;
+
+import org.postgresql.ssl.WrappedFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+public class TrustStoreLoader {
+    private static final Logger logger = LoggerFactory.getLogger(TrustStoreLoader.class);
+
+    private static final String CERTS_PATH;
+    private static final String TRUST_STORE_PASSWORD = "";
+
+    private static final KeyStore TRUST_STORE;
+
+    private static final SSLContext SSL_CONTEXT;
+
+    static {
+        CERTS_PATH = System.getenv("CERTS_PATH");
+
+        try {
+            TRUST_STORE = KeyStore.getInstance(KeyStore.getDefaultType());
+            TRUST_STORE.load(null, TRUST_STORE_PASSWORD.toCharArray());
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+            throw new RuntimeException("Could not create a keystore", e);
+        }
+
+        if (CERTS_PATH != null) {
+            try {
+                Files.walk(Paths.get(CERTS_PATH)).forEach(certPath -> {
+                    if (Files.isRegularFile(certPath)) {
+                        try {
+                            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                            Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
+                            TRUST_STORE.setCertificateEntry(certPath.getFileName().toString(), cert);
+                            logger.info("Loaded cert " + certPath);
+                        } catch (SecurityException | KeyStoreException | CertificateException | IOException e) {
+                            logger.error("Could not load " + certPath, e);
+                        }
+                    }
+                });
+            } catch (NoSuchFileException nsfe) {
+                logger.warn("Did not find any certificates to load");
+            } catch (IOException ioe) {
+                logger.error("Error walking certs directory", ioe);
+            }
+        }
+
+        try {
+            SSL_CONTEXT = SSLContext.getInstance("TLS");
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(TRUST_STORE);
+            SSL_CONTEXT.init(null, tmf.getTrustManagers(), null);
+        }
+        catch (GeneralSecurityException e) {
+            throw new RuntimeException("Could not initialize SSLContext", e);
+        }
+    }
+
+    public static KeyStore getTrustStore() {
+        return TRUST_STORE;
+    }
+
+    public static String getTrustStorePassword() {
+        return new String(TRUST_STORE_PASSWORD);
+    }
+
+    public static SSLContext getSSLContext() {
+        return SSL_CONTEXT;
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/util/TrustingSSLSocketFactory.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/TrustingSSLSocketFactory.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.publicauth.util;
+
+import org.postgresql.ssl.WrappedFactory;
+
+public class TrustingSSLSocketFactory  extends WrappedFactory {
+    public TrustingSSLSocketFactory() {
+        this._factory = TrustStoreLoader.getSSLContext().getSocketFactory();
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -19,7 +19,7 @@ database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}
   password: ${DB_PASSWORD}
-  url: ${DB_URL}
+  url: jdbc:postgresql://${DB_HOST}:5432/publicauth?ssl=true&sslfactory=uk.gov.pay.publicauth.util.TrustingSSLSocketFactory
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
Add required SSL options to enable Postgres TLS
Add picking up of certificates for Postgres TLS.

This param is already provided by Ansible. Yay!.

Merge after https://github.com/alphagov/pay-scripts/pull/175
