### PR TITLE
PP-182 Use DB_SSL_OPTION.

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -19,7 +19,7 @@ database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}
   password: ${DB_PASSWORD}
-  url: jdbc:postgresql://${DB_HOST}:5432/publicauth?ssl=true&sslfactory=uk.gov.pay.publicauth.util.TrustingSSLSocketFactory
+  url: jdbc:postgresql://${DB_HOST}:5432/publicauth?sslfactory=uk.gov.pay.publicauth.util.TrustingSSLSocketFactory&${DB_SSL_OPTION}
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
This will selectively enable/disable SSL when we're ready
Setting ssl=true for everywhere was a little hasty.

Option not being present defaults to SSL off which is right for prod for now.

Depends on https://github.com/alphagov/pay-scripts/pull/179/files
