### PR TITLE
Update Apache HttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,15 @@
             <artifactId>jbcrypt</artifactId>
             <version>0.3m</version>
         </dependency>
+
+        <dependency>
+            <!-- this has been added so we can use org.apache.http.conn.ssl.DefaultHostnameVerifier for Postgres.
+                it does not work with dropwizard 0.8.x but publicauth doesn't perform any outgoing HTTP calls -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+        </dependency>
+
         <!-- testing -->
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
Pull in a version of Apache HttpClient that has the DefaultHostNameVerifier class.

We need this to connect to Postgres and validate the upstream
certificate is correct. Although a better approach might be to find
a similar class rather than pulling in this entire library, this
is a pragmatic approach for now.
