### PR TITLE
PP-647 Connections recover after a DB loss

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -42,6 +42,9 @@ database:
   # whether or not idle connections should be validated
   checkConnectionWhileIdle: false
 
+  # whether or not connections should be validated before borrowing from the pool
+  checkConnectionOnBorrow: true
+
   # the amount of time to sleep between runs of the idle connection validation, abandoned cleaner and idle pool resizing
   evictionInterval: 10s
 


### PR DESCRIPTION
## WHAT
- Configuring the connection pool that makes it check for connections before
  returning it to the caller to perform jdbc operations. If the
  connection fails, then it drops it from the pool and creates a new
  one. While this will have slight overhead in running a validation
  query before returning the connection, it makes the application
  recoverable in the event of database going AWOL. By having this
  option, the application resumes operations as normal when the database
  is back.
## WHO

Any Dev
