### PR TITLE
PP-582 Adding Logging filter

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/filters/LoggingFilter.java
+++ b/src/main/java/uk/gov/pay/publicauth/filters/LoggingFilter.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.publicauth.filters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class LoggingFilter implements Filter {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        String requestURL = ((HttpServletRequest) servletRequest).getRequestURI();
+
+        logger.info("Start - publicauth request - " + requestURL);
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } catch (Throwable throwable){
+            logger.error("Exception - publicauth request - "+ requestURL + " - exception - "+ throwable.getMessage(), throwable);
+        }
+        finally {
+            logger.info("End - publicauth request - " + requestURL);
+        }
+    }
+
+    @Override
+    public void destroy() {}
+}

--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -29,11 +29,13 @@ import static uk.gov.pay.publicauth.util.ResponseUtil.notFoundResponse;
 @Path("/")
 public class PublicAuthResource {
 
+    public static final String API_VERSION_PATH = "/v1";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(PublicAuthResource.class);
 
     private static final ResponseBuilder UNAUTHORISED = status(Status.UNAUTHORIZED);
-    private static final String API_AUTH_PATH = "/v1/api/auth";
-    private static final String FRONTEND_AUTH_PATH = "/v1/frontend/auth";
+    private static final String API_AUTH_PATH = API_VERSION_PATH + "/api/auth";
+    private static final String FRONTEND_AUTH_PATH = API_VERSION_PATH + "/frontend/auth";
 
     private final AuthTokenDao authDao;
     private final TokenService tokenService;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
 database:
   driverClass: org.postgresql.Driver

--- a/src/test/java/uk/gov/pay/publicauth/filters/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/filters/LoggingFilterTest.java
@@ -1,0 +1,94 @@
+package uk.gov.pay.publicauth.filters;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoggingFilterTest {
+
+    private LoggingFilter loggingFilter;
+
+    @Mock
+    HttpServletRequest mockRequest;
+
+    @Mock
+    HttpServletResponse mockResponse;
+
+    @Mock
+    FilterChain mockFilterChain;
+
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @Before
+    public void setup() {
+        loggingFilter = new LoggingFilter();
+        Logger root = (Logger) LoggerFactory.getLogger(LoggingFilter.class);
+        mockAppender = mockAppender();
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void shouldLogEntryAndExitPointsOfEndPoints() throws Exception {
+
+        String requestUrl = "/publicauth-request";
+        when(mockRequest.getRequestURI()).thenReturn(requestUrl);
+        loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Start - publicauth request - " + requestUrl));
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is("End - publicauth request - " + requestUrl));
+        verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void shouldLogEntryAndExitPointsEvenWhenFilterChainingThrowsException() throws Exception {
+        String requestUrl = "/publicauth-url-with-exception";
+        when(mockRequest.getRequestURI()).thenReturn(requestUrl);
+
+        IOException exception = new IOException("Failed request");
+        doThrow(exception).when(mockFilterChain).doFilter(mockRequest, mockResponse);
+
+        loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Start - publicauth request - "+ requestUrl));
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is("Exception - publicauth request - "+ requestUrl + " - exception - "+ exception.getMessage()));
+        assertThat(loggingEvents.get(1).getLevel(), is(Level.ERROR));
+        assertThat(loggingEvents.get(1).getThrowableProxy().getMessage(), is("Failed request"));
+        assertThat(loggingEvents.get(2).getFormattedMessage(), is("End - publicauth request - "+ requestUrl));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Appender<T> mockAppender() {
+        return mock(Appender.class);
+    }
+
+}


### PR DESCRIPTION
## WHAT
- Introducing a Logging filter that would log all incoming requests with a prefix. Once the request is processed by the relevant resource it would also log the end of the chain with a prefix.
- Any exception thrown will also be logged with a prefix, exception message and the stack trace. A catch on this filter was opted against a ExceptionMapper so we can get a nice trace of start to finish (with
  erros)
- This gives us a nice trace of the request in the form of;
  start->error(if any)->end
- Log format changed to match other services.
## HOW TO REVIEW

Run a payment journey and you would see start->end logging.
## WHO

Any Dev
