### PR TITLE
PP-1753 Manually upgrade liquibase to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,17 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-migrations</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.liquibase</groupId>
+                    <artifactId>liquibase-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -17,10 +17,10 @@
             <column name="account_id" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="issued" type="timestamp without time zone" defaultValueComputed="(now() at time zone 'utc')">
+            <column name="issued" type="timestamp without timezone" defaultValueComputed="(now() at time zone 'utc')">
                 <constraints nullable="false"/>
             </column>
-            <column name="revoked" type="timestamp without time zone">
+            <column name="revoked" type="timestamp without timezone">
                 <constraints nullable="true"/>
             </column>
         </createTable>
@@ -67,7 +67,7 @@
         <addNotNullConstraint columnName="created_by" tableName="tokens"/>
 
         <addColumn tableName="tokens">
-            <column name="last_used" type="timestamp without time zone">
+            <column name="last_used" type="timestamp without timezone">
                 <constraints nullable="true"/>
             </column>
         </addColumn>


### PR DESCRIPTION
## WHAT
- After merging https://github.com/alphagov/pay-publicauth/pull/50, publicauth's cointainer is not   standing up at deploy time due to a failed checksum check
- The latest dropwizard brings in liquibase 3.5.1 which has introduced
  a regression issue. See (https://liquibase.jira.com/browse/CORE-2784)
  The fix tried in the previous PR worked in jenkins but failed at deploy time.
- This PR reverts the migrations.xml, and manually excludes the version
  3.5.1 of liquibase, bringing in 3.5.2.
- Will follow up with dropwizard about this issue.


## HOW 
_Steps to test or reproduce:_


