### PR TITLE
PP-1867 Add jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,57 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent any
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+  }
+
+  libraries {
+    lib("pay-jenkins-library@master")
+  }
+
+  environment {
+    DOCKER_HOST = "unix:///var/run/docker.sock"
+  }
+
+  stages {
+    stage('Maven Build') {
+      steps {
+        sh 'mvn clean package'
+      }
+    }
+    stage('Docker Build') {
+      steps {
+        script {
+          buildApp{
+            app = "publicauth"
+          }
+        }
+      }
+    }
+    stage('Test') {
+      steps {
+        runEndToEnd("publicauth")
+      }
+    }
+    stage('Docker Tag') {
+      steps {
+        script {
+          dockerTag {
+            app = "publicauth"
+          }
+        }
+      }
+    }
+    stage('Deploy') {
+      when {
+        branch 'master'
+      }
+      steps {
+        deploy("publicauth", "test", null, true)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a Jenkinsfile for pay-publicauth.

Immediately before merging, the following Jenkins jobs need to be disabled and deleted:

- trigger-pay-publicauth-master
- trigger-pay-publicauth-pull-request
- build-pay-publicauth
- deploy-publicauth

In addition, pay-chef needs to be modified to ensure the above jobs are not recreated.

Once this merged, existing branches will need a Jenkinsfile to get the full CI experience (new branches will inherit the one from master, of course).
