### PR TITLE
PP-2017 remove jstl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>3.5.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>jstl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
This was pulled by a transitive dependency of liquibase, although they themselves doesn't need it

