### PR TITLE
PP-2888 Add token_type to tokens table

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/auth/Token.java
+++ b/src/main/java/uk/gov/pay/publicauth/auth/Token.java
@@ -1,17 +1,29 @@
 package uk.gov.pay.publicauth.auth;
 
+import uk.gov.pay.publicauth.model.TokenPaymentType;
+
 import java.security.Principal;
 
 public class Token implements Principal {
 
     private final String name;
+    private final TokenPaymentType tokenPaymentType;
 
     public Token(String name) {
+        this(name, TokenPaymentType.CREDIT_CARD);
+}
+
+    public Token(String name, TokenPaymentType tokenPaymentType) {
         this.name = name;
+        this.tokenPaymentType = tokenPaymentType;
     }
 
     @Override
     public String getName() {
         return name;
+    }
+
+    public TokenPaymentType getTokenPaymentType() {
+        return tokenPaymentType;
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -4,6 +4,7 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.StringMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.model.TokenStateFilterParam;
 
 import java.util.List;
@@ -44,7 +45,7 @@ public class AuthTokenDao {
         String revokedDate = (tokenStateFilterParam.equals(TokenStateFilterParam.REVOKED)) ? "to_char(revoked,'DD Mon YYYY - HH24:MI') as revoked, " : "";
 
         return jdbi.withHandle(handle ->
-                handle.createQuery("SELECT token_link, description, " +
+                handle.createQuery("SELECT token_link, description, token_type, " +
                         "to_char(issued,'DD Mon YYYY - HH24:MI') as issued_date, " +
                         revokedDate +
                         "created_by, " +
@@ -63,10 +64,10 @@ public class AuthTokenDao {
         return rowsUpdated > 0;
     }
 
-    public void storeToken(String tokenHash, String randomTokenLink, String accountId, String description, String createdBy) {
+    public void storeToken(String tokenHash, String randomTokenLink, String accountId, String description, String createdBy, TokenPaymentType tokenPaymentType) {
         Integer rowsUpdated = jdbi.withHandle(handle ->
-                handle.insert("INSERT INTO tokens(token_hash, token_link, description, account_id, created_by) VALUES (?,?,?,?,?)",
-                        tokenHash, randomTokenLink, description, accountId, createdBy)
+                handle.insert("INSERT INTO tokens(token_hash, token_link, description, token_type, account_id, created_by) VALUES (?,?,?,?,?,?)",
+                        tokenHash, randomTokenLink, description, tokenPaymentType, accountId, createdBy)
         );
         if (rowsUpdated != 1) {
             LOGGER.error("Unable to store new token for account '{}'. '{}' rows were updated", accountId, rowsUpdated);
@@ -85,7 +86,7 @@ public class AuthTokenDao {
 
     public Optional<Map<String, Object>> findTokenByTokenLink(String tokenLink) {
         return Optional.ofNullable(jdbi.withHandle(handle ->
-                handle.createQuery("SELECT token_link, description, " +
+                handle.createQuery("SELECT token_link, description, token_type, " +
                         "to_char(revoked,'DD Mon YYYY - HH24:MI') as revoked, " +
                         "to_char(issued,'DD Mon YYYY - HH24:MI') as issued_date, " +
                         "created_by, " +

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenPaymentType.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenPaymentType.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.publicauth.model;
+
+public enum TokenPaymentType {
+    CREDIT_CARD, DIRECT_DEBIT;
+
+    public static TokenPaymentType fromString(final String type) {
+        try {
+            return TokenPaymentType.valueOf(type);
+        } catch (Exception e) {
+            return CREDIT_CARD;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.publicauth.auth.Token;
 import uk.gov.pay.publicauth.dao.AuthTokenDao;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.model.TokenStateFilterParam;
 import uk.gov.pay.publicauth.model.Tokens;
 import uk.gov.pay.publicauth.service.TokenService;
@@ -43,6 +44,7 @@ public class PublicAuthResource {
     public static final String ACCOUNT_ID_FIELD = "account_id";
     public static final String DESCRIPTION_FIELD = "description";
     public static final String CREATED_BY_FIELD = "created_by";
+    public static final String TOKEN_TYPE_FIELD = "token_type";
 
     private final AuthTokenDao authDao;
     private final TokenService tokenService;
@@ -58,8 +60,10 @@ public class PublicAuthResource {
     @GET
     public Response authenticate(@Auth Token token) {
         return authDao.findUnRevokedAccount(token.getName())
-                .map(accountId -> ok(ImmutableMap.of("account_id", accountId)))
-                .orElseGet(() -> UNAUTHORISED)
+                .map(accountId -> ok(ImmutableMap.of(
+                        "account_id", accountId,
+                        "token_type", token.getTokenPaymentType().toString())))
+                .orElse(UNAUTHORISED)
                 .build();
     }
 
@@ -72,10 +76,16 @@ public class PublicAuthResource {
                 .map(errorMessage -> badRequestResponse(LOGGER, errorMessage))
                 .orElseGet(() -> {
                     Tokens token = tokenService.issueTokens();
-                    authDao.storeToken(token.getHashedToken(), randomUUID().toString(),
+                    TokenPaymentType tokenPaymentType =
+                            Optional.ofNullable(payload.get(TOKEN_TYPE_FIELD))
+                                    .map(a -> TokenPaymentType.valueOf(a.asText()))
+                                    .orElse(TokenPaymentType.CREDIT_CARD);
+                    authDao.storeToken(token.getHashedToken(),
+                            randomUUID().toString(),
                             payload.get(ACCOUNT_ID_FIELD).asText(),
                             payload.get(DESCRIPTION_FIELD).asText(),
-                            payload.get(CREATED_BY_FIELD).asText());
+                            payload.get(CREATED_BY_FIELD).asText(),
+                            tokenPaymentType);
                     return ok(ImmutableMap.of("token", token.getApiKey())).build();
                 });
     }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -73,4 +73,12 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add token_type column to tokens table" author="">
+        <addColumn tableName="tokens">
+            <column name="token_type" type="varchar(36)" defaultValue="CREDIT_CARD">
+                <constraints nullable="false" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
 import java.util.List;
@@ -19,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNull;
+import static uk.gov.pay.publicauth.model.TokenPaymentType.CREDIT_CARD;
+import static uk.gov.pay.publicauth.model.TokenPaymentType.DIRECT_DEBIT;
 import static uk.gov.pay.publicauth.model.TokenStateFilterParam.*;
 
 public class AuthTokenDaoTest {
@@ -74,7 +77,7 @@ public class AuthTokenDaoTest {
         DateTime lastUsed = inserted.plusMinutes(30);
         DateTime revoked = inserted.plusMinutes(45);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, TEST_USER_NAME, lastUsed);
-        app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, TEST_USER_NAME_2, lastUsed);
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, TEST_USER_NAME_2, lastUsed, DIRECT_DEBIT);
 
         List<Map<String, Object>> tokens = authTokenDao.findTokensWithState(ACCOUNT_ID, ACTIVE);
 
@@ -85,6 +88,7 @@ public class AuthTokenDaoTest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(TEST_USER_NAME_2));
+        assertThat(firstToken.get("token_type"), is(DIRECT_DEBIT.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -106,19 +110,21 @@ public class AuthTokenDaoTest {
         assertThat(firstToken.containsKey("revoked"), is(true));
         assertThat(firstToken.get("revoked"), is(revoked.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("created_by"), is(TEST_USER_NAME));
+        assertThat(firstToken.get("token_type"), is(CREDIT_CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
 
     @Test
     public void shouldInsertNewToken() {
-        authTokenDao.storeToken("token-hash", "token-link", "account-id", "description", "user");
+        authTokenDao.storeToken("token-hash", "token-link", "account-id", "description", "user", CREDIT_CARD);
         Map<String, Object> tokenByHash = app.getDatabaseHelper().getTokenByHash("token-hash");
         DateTime now = app.getDatabaseHelper().getCurrentTime();
 
         assertThat(tokenByHash.get("token_hash"), is("token-hash"));
         assertThat(tokenByHash.get("account_id"), is("account-id"));
         assertThat(tokenByHash.get("description"), is("description"));
+        assertThat(tokenByHash.get("token_type"), is(CREDIT_CARD.toString()));
         assertThat(tokenByHash.get("created_by"), is("user"));
         assertNull(tokenByHash.get("last_used"));
         DateTime tokenIssueTime = app.getDatabaseHelper().issueTimestampForAccount("account-id");
@@ -211,7 +217,7 @@ public class AuthTokenDaoTest {
     public void shouldErrorIfTriesToSaveTheSameTokenTwice() throws Exception {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
-        authTokenDao.storeToken(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, "test@email.com");
+        authTokenDao.storeToken(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, "test@email.com", CREDIT_CARD);
     }
 
     private Matcher<ReadableInstant> isCloseTo(DateTime now) {

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -12,6 +12,7 @@ import org.joda.time.ReadableInstant;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
 import java.util.List;
@@ -25,9 +26,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.joda.time.DateTimeZone.*;
-import static uk.gov.pay.publicauth.resources.PublicAuthResource.ACCOUNT_ID_FIELD;
-import static uk.gov.pay.publicauth.resources.PublicAuthResource.CREATED_BY_FIELD;
-import static uk.gov.pay.publicauth.resources.PublicAuthResource.DESCRIPTION_FIELD;
+import static uk.gov.pay.publicauth.model.TokenPaymentType.*;
+import static uk.gov.pay.publicauth.resources.PublicAuthResource.*;
 
 public class PublicAuthResourceITest {
 
@@ -55,6 +55,12 @@ public class PublicAuthResourceITest {
     private String validTokenPayload = new Gson().toJson(
             ImmutableMap.of("account_id", ACCOUNT_ID,
                     "description", TOKEN_DESCRIPTION,
+                    "created_by", USER_EMAIL));
+
+    private String validTokenPayloadWithTokenType = new Gson().toJson(
+            ImmutableMap.of("account_id", ACCOUNT_ID,
+                    "description", TOKEN_DESCRIPTION,
+                    "token_type", TokenPaymentType.DIRECT_DEBIT.toString(),
                     "created_by", USER_EMAIL));
 
     @Test
@@ -108,6 +114,24 @@ public class PublicAuthResourceITest {
 
         Optional<String> newCreatedByEmail = app.getDatabaseHelper().lookupColumnForTokenTable(CREATED_BY_FIELD, TOKEN_HASH_COLUMN, hashedToken);
         assertThat(newCreatedByEmail.get(), equalTo(USER_EMAIL));
+
+        Optional<String> newTokenType = app.getDatabaseHelper().lookupColumnForTokenTable(TOKEN_TYPE_FIELD, TOKEN_HASH_COLUMN, hashedToken);
+        assertThat(newTokenType.get(), equalTo(TokenPaymentType.CREDIT_CARD.toString()));
+    }
+
+    @Test
+    public void respondWith200_whenCreateAToken_ifProvidedAccountIdDescriptionAndTokenType() throws Exception {
+        String newToken = createTokenFor(validTokenPayloadWithTokenType)
+                .statusCode(200)
+                .body("token", is(notNullValue()))
+                .extract().path("token");
+
+        int apiKeyHashSize = 32;
+        String tokenApiKey = newToken.substring(0, newToken.length() - apiKeyHashSize);
+        String hashedToken = BCrypt.hashpw(tokenApiKey, SALT);
+
+        Optional<String> newTokenType = app.getDatabaseHelper().lookupColumnForTokenTable(TOKEN_TYPE_FIELD, TOKEN_HASH_COLUMN, hashedToken);
+        assertThat(newTokenType.get(), equalTo(TokenPaymentType.DIRECT_DEBIT.toString()));
     }
 
     @Test
@@ -149,13 +173,8 @@ public class PublicAuthResourceITest {
     public void respondWith200_ifTokensHaveBeenIssuedForTheAccount() throws Exception {
         DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(UTC);
         DateTime lastUsed = inserted.plusHours(1);
-        DateTime revoked = new DateTime(UTC)
-                .plusDays(1)
-                .withHourOfDay(00)
-                .withMinuteOfHour(20)
-                .withSecondOfMinute(0);
 
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, CREATED_USER_NAME, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, CREATED_USER_NAME, lastUsed, DIRECT_DEBIT);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
 
         List<Map<String, String>> retrievedTokens = getTokensFor(ACCOUNT_ID)
@@ -166,20 +185,22 @@ public class PublicAuthResourceITest {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.size(), is(5));
+        assertThat(firstToken.size(), is(6));
         assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CREDIT_CARD.toString()));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
 
         Map<String, String> secondToken = retrievedTokens.get(1);
-        assertThat(secondToken.size(), is(5));
+        assertThat(secondToken.size(), is(6));
         assertThat(secondToken.get("token_link"), is(TOKEN_LINK));
         assertThat(secondToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(secondToken.containsKey("revoked"), is(false));
         assertThat(secondToken.get("created_by"), is(CREATED_USER_NAME));
+        assertThat(secondToken.get("token_type"), is(DIRECT_DEBIT.toString()));
         assertThat(secondToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
         assertThat(secondToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
     }
@@ -205,6 +226,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(firstToken.get("revoked"), is(revoked.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME));
+        assertThat(firstToken.get("token_type"), is(CREDIT_CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -228,6 +250,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CREDIT_CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -251,6 +274,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CREDIT_CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -273,6 +297,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CREDIT_CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -344,7 +369,8 @@ public class PublicAuthResourceITest {
                 .body("description", is(TOKEN_DESCRIPTION_2))
                 .body("issued_date", is(nowFromDB.toString("dd MMM YYYY - HH:mm")))
                 .body("last_used", is(nowFromDB.toString("dd MMM YYYY - HH:mm")))
-                .body("created_by", is(CREATED_USER_NAME));
+                .body("created_by", is(CREATED_USER_NAME))
+                .body("token_type", is(CREDIT_CARD.toString()));
 
         Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION_2));

--- a/src/test/java/uk/gov/pay/publicauth/model/TokenPaymentTypeTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/model/TokenPaymentTypeTest.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.publicauth.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+public class TokenPaymentTypeTest {
+
+    @Test
+    public void shouldParseDirectDebit() {
+        assertThat(TokenPaymentType.fromString("DIRECT_DEBIT"), is(TokenPaymentType.DIRECT_DEBIT));
+    }
+    @Test
+    public void shouldReturnActiveTokensIfTypeIsMissing() {
+        assertThat(TokenPaymentType.fromString(""), is(TokenPaymentType.CREDIT_CARD));
+    }
+}

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -4,6 +4,7 @@ import io.dropwizard.jdbi.args.JodaDateTimeMapper;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.StringMapper;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
 
 import java.util.Map;
 import java.util.Optional;
@@ -17,17 +18,21 @@ public class DatabaseTestHelper {
     }
 
     public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, DateTime.now());
+        insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, DateTime.now(), TokenPaymentType.CREDIT_CARD);
     }
 
     public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, DateTime revoked, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, DateTime.now());
+        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, DateTime.now(), TokenPaymentType.CREDIT_CARD);
     }
 
     public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, DateTime revoked, String createdBy, DateTime lastUsed) {
+        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, lastUsed, TokenPaymentType.CREDIT_CARD);
+    }
+
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, DateTime revoked, String createdBy, DateTime lastUsed, TokenPaymentType tokenPaymentType) {
             jdbi.withHandle(handle ->
-                    handle.insert("INSERT INTO tokens(token_hash, token_link, account_id, description, revoked, created_by, last_used) VALUES (?,?,?,?,(? at time zone 'utc'),?,(? at time zone 'utc'))",
-                            tokenHash, randomTokenLink, accountId, description, revoked, createdBy, lastUsed));
+                    handle.insert("INSERT INTO tokens(token_hash, token_link, account_id, description, token_type, revoked, created_by, last_used) VALUES (?,?,?,?,?,(? at time zone 'utc'),?,(? at time zone 'utc'))",
+                            tokenHash, randomTokenLink, accountId, description, tokenPaymentType.toString(), revoked, createdBy, lastUsed));
     }
 
     public DateTime issueTimestampForAccount(String accountId) {
@@ -49,7 +54,7 @@ public class DatabaseTestHelper {
 
     public Map<String, Object> getTokenByHash(String tokenHash) {
         Map<String, Object> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT token_id, token_hash, account_id, issued, revoked, token_link, description, created_by " +
+                h.createQuery("SELECT token_id, token_hash, account_id, token_type, issued, revoked, token_link, description, created_by " +
                         "FROM tokens t " +
                         "WHERE token_hash = :token_hash")
                         .bind("token_hash", tokenHash)


### PR DESCRIPTION
## WHAT
 - We are introducing a new payment type, direct debit. Currently we plan to associate a gateway account to one of the two payment types.
 - This PR adds a new column to the tokens table, `token_type`, which can be of type `CREDIT_CARD` or `DIRECT_DEBIT`. The type has to be specified when storing (creating) the token.
 - For backwards compatibility, if there's no `token_type` field in the token creation request payload, the type is defaulting to `CREDIT_CARD`.
 - The `token_type` is returned as part of the authorised account, to be propagated to public api


