### PR TITLE
PP-2888 Add token_type column to tokens table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -73,4 +73,11 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add token_type column to tokens table" author="">
+        <addColumn tableName="tokens">
+            <column name="token_type" type="varchar(36)" defaultValue="CREDIT_CARD">
+                <constraints nullable="false" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -75,7 +75,7 @@
 
     <changeSet id="add token_type column to tokens table" author="">
         <addColumn tableName="tokens">
-            <column name="token_type" type="varchar(36)" defaultValue="CREDIT_CARD">
+            <column name="token_type" type="varchar(36)" defaultValue="CARD">
                 <constraints nullable="false" unique="false"/>
             </column>
         </addColumn>


### PR DESCRIPTION
## WHAT
- This PR adds a new column to the tokens table, `token_type`, which can be of type `CARD` or `DIRECT_DEBIT`. The type has to be specified when storing (creating) the token.


