### PR TITLE
PP-2888 Add token_type to tokens table (again)

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -72,5 +72,14 @@
             </column>
         </addColumn>
     </changeSet>
+    
+    <changeSet id="add token_type column to tokens table" author="">
+        <addColumn tableName="tokens">
+            <column name="token_type" type="varchar(36)">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
 
+        <addDefaultValue tableName="tokens" columnName="token_type" defaultValue="CARD"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
This PR adds a new column to the tokens table, token_type, which can be of type CARD or DIRECT_DEBIT. 

We previously merged https://github.com/alphagov/pay-publicauth/pull/67 which introduced a performance issue on staging when backfilling the data, due to the high number of tokens in staging/prod created by smoke tests. 
At the moment, we are *not* backfilling the data.

