### PR TITLE
PP-2888 Add token_type support

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/auth/Token.java
+++ b/src/main/java/uk/gov/pay/publicauth/auth/Token.java
@@ -1,17 +1,29 @@
 package uk.gov.pay.publicauth.auth;
 
+import uk.gov.pay.publicauth.model.TokenPaymentType;
+
 import java.security.Principal;
 
 public class Token implements Principal {
 
     private final String name;
+    private final TokenPaymentType tokenPaymentType;
 
     public Token(String name) {
+        this(name, TokenPaymentType.CARD);
+    }
+
+    public Token(String name, TokenPaymentType tokenPaymentType) {
         this.name = name;
+        this.tokenPaymentType = tokenPaymentType;
     }
 
     @Override
     public String getName() {
         return name;
+    }
+
+    public TokenPaymentType getTokenPaymentType() {
+        return tokenPaymentType;
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenPaymentType.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenPaymentType.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.publicauth.model;
+
+public enum TokenPaymentType {
+    CARD, DIRECT_DEBIT;
+
+    public static TokenPaymentType fromString(final String type) {
+        try {
+            return TokenPaymentType.valueOf(type);
+        } catch (Exception e) {
+            return CARD;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -12,6 +12,7 @@ import org.joda.time.ReadableInstant;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
 import java.util.List;
@@ -25,9 +26,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.joda.time.DateTimeZone.*;
-import static uk.gov.pay.publicauth.resources.PublicAuthResource.ACCOUNT_ID_FIELD;
-import static uk.gov.pay.publicauth.resources.PublicAuthResource.CREATED_BY_FIELD;
-import static uk.gov.pay.publicauth.resources.PublicAuthResource.DESCRIPTION_FIELD;
+import static uk.gov.pay.publicauth.model.TokenPaymentType.*;
+import static uk.gov.pay.publicauth.resources.PublicAuthResource.*;
 
 public class PublicAuthResourceITest {
 
@@ -56,7 +56,11 @@ public class PublicAuthResourceITest {
             ImmutableMap.of("account_id", ACCOUNT_ID,
                     "description", TOKEN_DESCRIPTION,
                     "created_by", USER_EMAIL));
-
+    private String validTokenPayloadWithTokenType = new Gson().toJson(
+            ImmutableMap.of("account_id", ACCOUNT_ID,
+                    "description", TOKEN_DESCRIPTION,
+                    "token_type", DIRECT_DEBIT.toString(),
+                    "created_by", USER_EMAIL));
     @Test
     public void respondWith200_whenAuthWithValidToken() throws Exception {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
@@ -108,6 +112,24 @@ public class PublicAuthResourceITest {
 
         Optional<String> newCreatedByEmail = app.getDatabaseHelper().lookupColumnForTokenTable(CREATED_BY_FIELD, TOKEN_HASH_COLUMN, hashedToken);
         assertThat(newCreatedByEmail.get(), equalTo(USER_EMAIL));
+
+        Optional<String> newTokenType = app.getDatabaseHelper().lookupColumnForTokenTable(TOKEN_TYPE_FIELD, TOKEN_HASH_COLUMN, hashedToken);
+        assertThat(newTokenType.get(), equalTo(CARD.toString()));
+    }
+
+    @Test
+    public void respondWith200_whenCreateAToken_ifProvidedAccountIdDescriptionAndTokenType() throws Exception {
+        String newToken = createTokenFor(validTokenPayloadWithTokenType)
+                .statusCode(200)
+                .body("token", is(notNullValue()))
+                .extract().path("token");
+
+        int apiKeyHashSize = 32;
+        String tokenApiKey = newToken.substring(0, newToken.length() - apiKeyHashSize);
+        String hashedToken = BCrypt.hashpw(tokenApiKey, SALT);
+
+        Optional<String> newTokenType = app.getDatabaseHelper().lookupColumnForTokenTable(TOKEN_TYPE_FIELD, TOKEN_HASH_COLUMN, hashedToken);
+        assertThat(newTokenType.get(), equalTo(DIRECT_DEBIT.toString()));
     }
 
     @Test
@@ -156,7 +178,7 @@ public class PublicAuthResourceITest {
                 .withSecondOfMinute(0);
 
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, CREATED_USER_NAME, lastUsed);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed, DIRECT_DEBIT);
 
         List<Map<String, String>> retrievedTokens = getTokensFor(ACCOUNT_ID)
                 .statusCode(200)
@@ -166,20 +188,22 @@ public class PublicAuthResourceITest {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.size(), is(5));
+        assertThat(firstToken.size(), is(6));
         assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(DIRECT_DEBIT.toString()));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
 
         Map<String, String> secondToken = retrievedTokens.get(1);
-        assertThat(secondToken.size(), is(5));
+        assertThat(secondToken.size(), is(6));
         assertThat(secondToken.get("token_link"), is(TOKEN_LINK));
         assertThat(secondToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(secondToken.containsKey("revoked"), is(false));
         assertThat(secondToken.get("created_by"), is(CREATED_USER_NAME));
+        assertThat(secondToken.get("token_type"), is(CARD.toString()));
         assertThat(secondToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
         assertThat(secondToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
     }
@@ -205,6 +229,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(firstToken.get("revoked"), is(revoked.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME));
+        assertThat(firstToken.get("token_type"), is(CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -228,6 +253,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -251,6 +277,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -273,6 +300,7 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CARD.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
         assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
     }
@@ -344,7 +372,8 @@ public class PublicAuthResourceITest {
                 .body("description", is(TOKEN_DESCRIPTION_2))
                 .body("issued_date", is(nowFromDB.toString("dd MMM YYYY - HH:mm")))
                 .body("last_used", is(nowFromDB.toString("dd MMM YYYY - HH:mm")))
-                .body("created_by", is(CREATED_USER_NAME));
+                .body("created_by", is(CREATED_USER_NAME))
+                .body("token_type", is(CARD.toString()));
 
         Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION_2));

--- a/src/test/java/uk/gov/pay/publicauth/model/TokenPaymentTypeTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/model/TokenPaymentTypeTest.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.publicauth.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+public class TokenPaymentTypeTest {
+
+    @Test
+    public void shouldParseDirectDebit() {
+        assertThat(TokenPaymentType.fromString("DIRECT_DEBIT"), is(TokenPaymentType.DIRECT_DEBIT));
+    }
+    @Test
+    public void shouldReturnCardIfTypeIsMissing() {
+        assertThat(TokenPaymentType.fromString(""), is(TokenPaymentType.CARD));
+    }
+    @Test
+    public void shouldReturnCardIfTypeIsNull() {
+        assertThat(TokenPaymentType.fromString(null), is(TokenPaymentType.CARD));
+    }
+}


### PR DESCRIPTION
## WHAT
- We are introducing a new payment type, direct debit. Currently we plan to associate a gateway_account to one of the two payment types.
- This PR adds a new column to the tokens table, `token_type`, which can be of type `CARD` or `DIRECT_DEBIT`. The type has to be specified when storing (creating) the token.
- For backwards compatibility, if there's no `token_type` field in the token creation request payload, or the token_type in the db is NULL, the type defaults to `CARD`
- This PR depends on https://github.com/alphagov/pay-publicauth/pull/71, which introduces the new column in the db


