### PR TITLE
PP-2888 Retrieve token_type from the db when authorising account

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/auth/Token.java
+++ b/src/main/java/uk/gov/pay/publicauth/auth/Token.java
@@ -1,29 +1,17 @@
 package uk.gov.pay.publicauth.auth;
 
-import uk.gov.pay.publicauth.model.TokenPaymentType;
-
 import java.security.Principal;
 
 public class Token implements Principal {
 
     private final String name;
-    private final TokenPaymentType tokenPaymentType;
 
     public Token(String name) {
-        this(name, TokenPaymentType.CARD);
-    }
-
-    public Token(String name, TokenPaymentType tokenPaymentType) {
         this.name = name;
-        this.tokenPaymentType = tokenPaymentType;
     }
 
     @Override
     public String getName() {
         return name;
-    }
-
-    public TokenPaymentType getTokenPaymentType() {
-        return tokenPaymentType;
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -22,11 +22,10 @@ public class AuthTokenDao {
     }
 
 
-    public Optional<String> findUnRevokedAccount(String tokenHash) {
-        Optional<String> storedTokenHash = Optional.ofNullable(jdbi.withHandle(handle ->
-                handle.createQuery("SELECT account_id FROM tokens WHERE token_hash = :token_hash AND revoked IS NULL")
+    public Optional<Map<String, Object>> findUnRevokedAccount(String tokenHash) {
+        Optional<Map<String, Object>> storedTokenHash = Optional.ofNullable(jdbi.withHandle(handle ->
+                handle.createQuery("SELECT account_id, coalesce(token_type, 'CARD') as token_type FROM tokens WHERE token_hash = :token_hash AND revoked IS NULL")
                         .bind("token_hash", tokenHash)
-                        .map(StringMapper.FIRST)
                         .first()));
         if (storedTokenHash.isPresent()) {
             updateLastUsedTime(tokenHash);

--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -61,9 +61,9 @@ public class PublicAuthResource {
     @GET
     public Response authenticate(@Auth Token token) {
         return authDao.findUnRevokedAccount(token.getName())
-                .map(accountId -> ok(ImmutableMap.of(
-                        "account_id", accountId,
-                        "token_type", token.getTokenPaymentType().toString())))
+                .map(tokenInfo -> ok(ImmutableMap.of(
+                        "account_id", tokenInfo.get("account_id"),
+                        "token_type", tokenInfo.get("token_type").toString())))
                 .orElse(UNAUTHORISED)
                 .build();
     }
@@ -79,7 +79,7 @@ public class PublicAuthResource {
                     Tokens token = tokenService.issueTokens();
                     TokenPaymentType tokenPaymentType =
                             Optional.ofNullable(payload.get(TOKEN_TYPE_FIELD))
-                                    .map(a -> valueOf(a.asText()))
+                                    .map(tokenType -> valueOf(tokenType.asText()))
                                     .orElse(CARD);
                     authDao.storeToken(token.getHashedToken(),
                             randomUUID().toString(),

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
@@ -51,11 +51,28 @@ public class AuthTokenDaoTest {
     }
 
     @Test
-    public void findAnAccountIdAndTokenTypeByToken() throws Exception {
+    public void findAnAccountIdAndTokenTypeByToken_ifTokenTypeIsDirectDebit() throws Exception {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, null, DIRECT_DEBIT);
         Optional<Map<String, Object>> tokenInfo = authTokenDao.findUnRevokedAccount(TOKEN_HASH);
         assertThat(tokenInfo.get().get("account_id"), is(ACCOUNT_ID));
         assertThat(tokenInfo.get().get("token_type"), is(DIRECT_DEBIT.toString()));
+    }
+
+
+    @Test
+    public void findAnAccountIdAndTokenTypeByToken_ifTokenTypeIsCard() throws Exception {
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, null, CARD);
+        Optional<Map<String, Object>> tokenInfo = authTokenDao.findUnRevokedAccount(TOKEN_HASH);
+        assertThat(tokenInfo.get().get("account_id"), is(ACCOUNT_ID));
+        assertThat(tokenInfo.get().get("token_type"), is(CARD.toString()));
+    }
+
+    @Test
+    public void findAnAccountIdAndTokenTypeByToken_ifTokenTypeIsNull() throws Exception {
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, null, null);
+        Optional<Map<String, Object>> tokenInfo = authTokenDao.findUnRevokedAccount(TOKEN_HASH);
+        assertThat(tokenInfo.get().get("account_id"), is(ACCOUNT_ID));
+        assertThat(tokenInfo.get().get("token_type"), is(CARD.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
@@ -51,17 +51,17 @@ public class AuthTokenDaoTest {
     }
 
     @Test
-    public void findAnAccountIdByToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
-
-        Optional<String> accountId = authTokenDao.findUnRevokedAccount(TOKEN_HASH);
-        assertThat(accountId, is(Optional.of(ACCOUNT_ID)));
+    public void findAnAccountIdAndTokenTypeByToken() throws Exception {
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, null, DIRECT_DEBIT);
+        Optional<Map<String, Object>> tokenInfo = authTokenDao.findUnRevokedAccount(TOKEN_HASH);
+        assertThat(tokenInfo.get().get("account_id"), is(ACCOUNT_ID));
+        assertThat(tokenInfo.get().get("token_type"), is(DIRECT_DEBIT.toString()));
     }
 
     @Test
-    public void missingTokenHasNoAccount() throws Exception {
-        Optional<String> accountId = authTokenDao.findUnRevokedAccount(TOKEN_HASH);
-        assertThat(accountId, is(Optional.empty()));
+    public void missingTokenHasNoInfo() throws Exception {
+        Optional<Map<String, Object>> tokenInfo = authTokenDao.findUnRevokedAccount(TOKEN_HASH);
+        assertThat(tokenInfo, is(Optional.empty()));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Working on the wrong assumption that the token_type is embedded in the token.
  This PR retrieves the token_type from the db, where it is stored, together
  with account_id


## HOW 
_Steps to test or reproduce:_


