### PR TITLE
PP-3065 Better logging in publicauth

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/filters/LoggingFilter.java
+++ b/src/main/java/uk/gov/pay/publicauth/filters/LoggingFilter.java
@@ -1,6 +1,8 @@
 package uk.gov.pay.publicauth.filters;
 
 import com.google.common.base.Stopwatch;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.logging.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +16,7 @@ import static java.lang.String.format;
 
 public class LoggingFilter implements Filter {
 
-    public static final String HEADER_REQUEST_ID = "Request-Id";
+    public static final String HEADER_REQUEST_ID = "X-Request-Id";
     private static final Logger logger = LoggerFactory.getLogger(LoggingFilter.class);
 
     @Override
@@ -27,8 +29,9 @@ public class LoggingFilter implements Filter {
 
         String requestURL = ((HttpServletRequest) servletRequest).getRequestURI();
         String requestMethod = ((HttpServletRequest) servletRequest).getMethod();
-        Optional<String> requestIdMaybe = Optional.ofNullable(((HttpServletRequest) servletRequest).getHeader(HEADER_REQUEST_ID));
-        String requestId = requestIdMaybe.orElse("");
+        String requestId = StringUtils.defaultString(((HttpServletRequest) servletRequest).getHeader(HEADER_REQUEST_ID));
+
+        MDC.put(HEADER_REQUEST_ID, requestId);
 
         logger.info(format("[%s] - %s to %s began", requestId, requestMethod, requestURL));
         try {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %level %logger{15} [requestID=%X{X-Request-Id}] - %msg %n"
 
 database:
   driverClass: org.postgresql.Driver

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -383,7 +383,7 @@ public class PublicAuthResourceITest {
     public void respondWith404_ifUpdatingDescriptionOfNonExistingToken() throws Exception {
         updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not update token description"));
+                .body("message", is("Could not update description of token with token_link " + TOKEN_LINK));
 
         Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
         assertThat(descriptionInDb.isPresent(), is(false));
@@ -395,7 +395,7 @@ public class PublicAuthResourceITest {
 
         updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not update token description"));
+                .body("message", is("Could not update description of token with token_link " + TOKEN_LINK));
 
         Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
@@ -444,7 +444,7 @@ public class PublicAuthResourceITest {
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK_2 + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token"));
+                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK_2));
 
         Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
         assertThat(token1RevokedInDb.isPresent(), is(false));
@@ -458,7 +458,7 @@ public class PublicAuthResourceITest {
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token"));
+                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK ));
 
         Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
         assertThat(token1RevokedInDb.isPresent(), is(true));
@@ -468,7 +468,7 @@ public class PublicAuthResourceITest {
     public void respondWith404_whenTokenDoesNotExist() throws Exception {
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token"));
+                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK));
 
         Optional<String> tokenLinkdInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK);
         assertThat(tokenLinkdInDb.isPresent(), is(false));


### PR DESCRIPTION
## WHAT
 - Propagating the `X-Request-Id` header coming from nginx in each log line, via MDC
 - Removing colors from logs, as they are not visible where we store our logs anyway
 - Adding some additional log lines to explain what publicauth is actually doing

## HOW 
_Steps to test or reproduce:_


