### PR TITLE
PP-3061 Remove JodaTime in favour of Java 8 API

### DIFF
--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
@@ -97,7 +97,7 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldFindActiveTokens() throws Exception {
-        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime inserted = app.getDatabaseHelper().getCurrentTime();
         ZonedDateTime lastUsed = inserted.plusMinutes(30);
         ZonedDateTime revoked = inserted.plusMinutes(45);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, TEST_USER_NAME, lastUsed);
@@ -119,7 +119,7 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldReturnCardTokensIfTokenTypeIsNull() throws Exception {
-        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime inserted = app.getDatabaseHelper().getCurrentTime();
         ZonedDateTime lastUsed = inserted.plusMinutes(30);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, TEST_USER_NAME_2, lastUsed, null);
 
@@ -139,7 +139,7 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldFindRevokedTokens() throws Exception {
-        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime inserted = app.getDatabaseHelper().getCurrentTime();
         ZonedDateTime lastUsed = inserted.plusMinutes(30);
         ZonedDateTime revoked = inserted.plusMinutes(45);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, TEST_USER_NAME, lastUsed);
@@ -162,7 +162,7 @@ public class AuthTokenDaoTest {
     public void shouldInsertNewToken() {
         authTokenDao.storeToken("token-hash", "token-link", "account-id", "description", "user", CARD);
         Map<String, Object> tokenByHash = app.getDatabaseHelper().getTokenByHash("token-hash");
-        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime now = app.getDatabaseHelper().getCurrentTime();
 
         assertThat(tokenByHash.get("token_hash"), is("token-hash"));
         assertThat(tokenByHash.get("account_id"), is("account-id"));
@@ -186,7 +186,7 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldFindTokenByTokenLink() throws Exception {
-        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime now = app.getDatabaseHelper().getCurrentTime();
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, now, DIRECT_DEBIT);
         Optional<Map<String, Object>> tokenMayBe = authTokenDao.findTokenByTokenLink(TOKEN_LINK);
         Map<String, Object> token = tokenMayBe.get();
@@ -202,7 +202,7 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldFindByTokenLinkAndReturnCardTokensIfTokenTypeIsNull() throws Exception {
-        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime now = app.getDatabaseHelper().getCurrentTime();
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, now, null);
         Optional<Map<String, Object>> tokenMayBe = authTokenDao.findTokenByTokenLink(TOKEN_LINK);
         Map<String, Object> token = tokenMayBe.get();

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
@@ -2,15 +2,16 @@ package uk.gov.pay.publicauth.dao;
 
 import com.google.common.collect.Lists;
 import org.hamcrest.Matcher;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.ReadableInstant;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +33,9 @@ public class AuthTokenDaoTest {
 
     public static final String TEST_USER_NAME = "test-user-name";
     public static final String TEST_USER_NAME_2 = "test-user-name-2";
-    private  DateTime now = DateTime.now();
+
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd MMM YYYY - HH:mm");
+
 
     @Rule
     public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
@@ -94,9 +97,9 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldFindActiveTokens() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(DateTimeZone.UTC);
-        DateTime lastUsed = inserted.plusMinutes(30);
-        DateTime revoked = inserted.plusMinutes(45);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusMinutes(30);
+        ZonedDateTime revoked = inserted.plusMinutes(45);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, TEST_USER_NAME, lastUsed);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, TEST_USER_NAME_2, lastUsed, DIRECT_DEBIT);
 
@@ -110,14 +113,14 @@ public class AuthTokenDaoTest {
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(TEST_USER_NAME_2));
         assertThat(firstToken.get("token_type"), is(DIRECT_DEBIT.toString()));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void shouldReturnCardTokensIfTokenTypeIsNull() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(DateTimeZone.UTC);
-        DateTime lastUsed = inserted.plusMinutes(30);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusMinutes(30);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, TEST_USER_NAME_2, lastUsed, null);
 
         List<Map<String, Object>> tokens = authTokenDao.findTokensWithState(ACCOUNT_ID, ACTIVE);
@@ -130,15 +133,15 @@ public class AuthTokenDaoTest {
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(TEST_USER_NAME_2));
         assertThat(firstToken.get("token_type"), is(CARD.toString()));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void shouldFindRevokedTokens() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(DateTimeZone.UTC);
-        DateTime lastUsed = inserted.plusMinutes(30);
-        DateTime revoked = inserted.plusMinutes(45);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusMinutes(30);
+        ZonedDateTime revoked = inserted.plusMinutes(45);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, TEST_USER_NAME, lastUsed);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, TEST_USER_NAME_2, lastUsed);
 
@@ -149,17 +152,17 @@ public class AuthTokenDaoTest {
         assertThat(firstToken.get("token_link"), is(TOKEN_LINK));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(firstToken.containsKey("revoked"), is(true));
-        assertThat(firstToken.get("revoked"), is(revoked.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("revoked"), is(revoked.format(DATE_TIME_FORMAT)));
         assertThat(firstToken.get("created_by"), is(TEST_USER_NAME));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void shouldInsertNewToken() {
         authTokenDao.storeToken("token-hash", "token-link", "account-id", "description", "user", CARD);
         Map<String, Object> tokenByHash = app.getDatabaseHelper().getTokenByHash("token-hash");
-        DateTime now = app.getDatabaseHelper().getCurrentTime();
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
 
         assertThat(tokenByHash.get("token_hash"), is("token-hash"));
         assertThat(tokenByHash.get("account_id"), is("account-id"));
@@ -167,7 +170,7 @@ public class AuthTokenDaoTest {
         assertThat(tokenByHash.get("created_by"), is("user"));
         assertNull(tokenByHash.get("last_used"));
         assertThat(tokenByHash.get("token_type"), is(CARD.toString()));
-        DateTime tokenIssueTime = app.getDatabaseHelper().issueTimestampForAccount("account-id");
+        ZonedDateTime tokenIssueTime = app.getDatabaseHelper().issueTimestampForAccount("account-id");
         assertThat(tokenIssueTime, isCloseTo(now));
     }
 
@@ -183,8 +186,8 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldFindTokenByTokenLink() throws Exception {
-        DateTime nowFromDB = app.getDatabaseHelper().getCurrentTime().toDateTime(DateTimeZone.UTC);
-        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, nowFromDB, DIRECT_DEBIT);
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, now, DIRECT_DEBIT);
         Optional<Map<String, Object>> tokenMayBe = authTokenDao.findTokenByTokenLink(TOKEN_LINK);
         Map<String, Object> token = tokenMayBe.get();
 
@@ -193,14 +196,14 @@ public class AuthTokenDaoTest {
         assertThat(TEST_USER_NAME, is(token.get("created_by")));
         assertThat(token.get("token_type"), is(DIRECT_DEBIT.toString()));
         assertThat(token.get("revoked"), is(nullValue()));
-        assertThat(token.get("issued_date"), is(nowFromDB.toString("dd MMM YYYY - HH:mm")));
-        assertThat(token.get("last_used"), is(nowFromDB.toString("dd MMM YYYY - HH:mm")));
+        assertThat(token.get("issued_date"), is(now.format(DATE_TIME_FORMAT)));
+        assertThat(token.get("last_used"), is(now.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void shouldFindByTokenLinkAndReturnCardTokensIfTokenTypeIsNull() throws Exception {
-        DateTime nowFromDB = app.getDatabaseHelper().getCurrentTime().toDateTime(DateTimeZone.UTC);
-        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, nowFromDB, null);
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, now, null);
         Optional<Map<String, Object>> tokenMayBe = authTokenDao.findTokenByTokenLink(TOKEN_LINK);
         Map<String, Object> token = tokenMayBe.get();
         assertThat(TOKEN_LINK, is(token.get("token_link")));
@@ -208,8 +211,8 @@ public class AuthTokenDaoTest {
         assertThat(TEST_USER_NAME, is(token.get("created_by")));
         assertThat(token.get("token_type"), is(CARD.toString()));
         assertThat(token.get("revoked"), is(nullValue()));
-        assertThat(token.get("issued_date"), is(nowFromDB.toString("dd MMM YYYY - HH:mm")));
-        assertThat(token.get("last_used"), is(nowFromDB.toString("dd MMM YYYY - HH:mm")));
+        assertThat(token.get("issued_date"), is(now.format(DATE_TIME_FORMAT)));
+        assertThat(token.get("last_used"), is(now.format(DATE_TIME_FORMAT)));
     }
 
     @Test
@@ -223,7 +226,7 @@ public class AuthTokenDaoTest {
 
     @Test
     public void notUpdateARevokedToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, DateTime.now(), TEST_USER_NAME);
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), TEST_USER_NAME);
 
         boolean updateResult = authTokenDao.updateTokenDescription(TOKEN_LINK, TOKEN_DESCRIPTION_2);
 
@@ -238,7 +241,7 @@ public class AuthTokenDaoTest {
 
         Optional<String> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
 
-        assertThat(revokedDate.get(), is(now.toString("dd MMM YYYY")));
+        assertThat(revokedDate.get(), is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
         assertThat(revokedInDb.isPresent(), is(true));
@@ -259,7 +262,7 @@ public class AuthTokenDaoTest {
 
     @Test
     public void shouldNotRevokeATokenAlreadyRevoked() throws Exception {
-        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, DateTime.now(), TEST_USER_NAME);
+        app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), TEST_USER_NAME);
 
         Optional<String> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
 
@@ -276,7 +279,7 @@ public class AuthTokenDaoTest {
         authTokenDao.storeToken(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, "test@email.com", CARD);
     }
 
-    private Matcher<ReadableInstant> isCloseTo(DateTime now) {
+    private Matcher<ChronoZonedDateTime<?>> isCloseTo(ZonedDateTime now) {
         return both(greaterThan(now.minusSeconds(5))).and(lessThan(now.plusSeconds(5)));
     }
 }

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -6,15 +6,15 @@ import com.google.gson.Gson;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.apache.commons.codec.digest.HmacUtils;
 import org.hamcrest.Matcher;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.ReadableInstant;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;
-import uk.gov.pay.publicauth.resources.PublicAuthResource;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,11 +31,12 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
-import static org.joda.time.DateTimeZone.UTC;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.DIRECT_DEBIT;
 
 public class PublicAuthResourceITest {
+
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd MMM YYYY - HH:mm");
 
     private static final String SALT = "$2a$10$IhaXo6LIBhKIWOiGpbtPOu";
     private static final String BEARER_TOKEN = "testbearertoken";
@@ -53,8 +54,6 @@ public class PublicAuthResourceITest {
     private static final String TOKEN_HASH_COLUMN = "token_hash";
     private static final String CREATED_USER_NAME = "user-name";
     private static final String CREATED_USER_NAME2 = "user-name-2";
-
-    private DateTime now = DateTime.now();
 
     @Rule
     public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
@@ -74,19 +73,19 @@ public class PublicAuthResourceITest {
         tokenResponse(apiKey)
                 .statusCode(200)
                 .body("account_id", is(ACCOUNT_ID));
-        DateTime lastUsed = app.getDatabaseHelper().getDateTimeColumn("last_used", ACCOUNT_ID);
-        DateTime currentTimeInDb = app.getDatabaseHelper().getCurrentTime();
-        assertThat(lastUsed, isCloseTo(currentTimeInDb));
+        ZonedDateTime lastUsed = app.getDatabaseHelper().getDateTimeColumn("last_used", ACCOUNT_ID);
+        assertThat(lastUsed, isCloseTo(ZonedDateTime.now(ZoneOffset.UTC)));
     }
 
     @Test
     public void respondWith401_whenAuthWithRevokedToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, DateTime.now(), CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION,
+                ZonedDateTime.now(ZoneOffset.UTC), CREATED_USER_NAME);
         String apiKey = BEARER_TOKEN + encodedHmacValueOf(BEARER_TOKEN);
-        DateTime lastUsedPreAuth = app.getDatabaseHelper().getDateTimeColumn("last_used", ACCOUNT_ID);
+        ZonedDateTime lastUsedPreAuth = app.getDatabaseHelper().getDateTimeColumn("last_used", ACCOUNT_ID);
         tokenResponse(apiKey)
                 .statusCode(401);
-        DateTime lastUsedPostAuth = app.getDatabaseHelper().getDateTimeColumn("last_used", ACCOUNT_ID);
+        ZonedDateTime lastUsedPostAuth = app.getDatabaseHelper().getDateTimeColumn("last_used", ACCOUNT_ID);
 
         assertThat(lastUsedPreAuth, is(lastUsedPostAuth));
     }
@@ -175,13 +174,8 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith200_ifTokensHaveBeenIssuedForTheAccount() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(UTC);
-        DateTime lastUsed = inserted.plusHours(1);
-        DateTime revoked = new DateTime(UTC)
-                .plusDays(1)
-                .withHourOfDay(00)
-                .withMinuteOfHour(20)
-                .withSecondOfMinute(0);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusHours(1);
 
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, CREATED_USER_NAME, lastUsed);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed, DIRECT_DEBIT);
@@ -200,8 +194,8 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
         assertThat(firstToken.get("token_type"), is(DIRECT_DEBIT.toString()));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
 
         Map<String, String> secondToken = retrievedTokens.get(1);
         assertThat(secondToken.size(), is(6));
@@ -210,15 +204,15 @@ public class PublicAuthResourceITest {
         assertThat(secondToken.containsKey("revoked"), is(false));
         assertThat(secondToken.get("created_by"), is(CREATED_USER_NAME));
         assertThat(secondToken.get("token_type"), is(CARD.toString()));
-        assertThat(secondToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
-        assertThat(secondToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
+        assertThat(secondToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
+        assertThat(secondToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void respondWith200_andRetrieveRevokedTokens() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(DateTimeZone.UTC);
-        DateTime lastUsed = inserted.plusHours(1);
-        DateTime revoked = inserted.plusHours(2);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusHours(1);
+        ZonedDateTime revoked = inserted.plusHours(2);
 
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
@@ -233,18 +227,18 @@ public class PublicAuthResourceITest {
         Map<String, String> firstToken = retrievedTokens.get(0);
         assertThat(firstToken.get("token_link"), is(TOKEN_LINK));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
-        assertThat(firstToken.get("revoked"), is(revoked.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("revoked"), is(revoked.format(DATE_TIME_FORMAT)));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME));
         assertThat(firstToken.get("token_type"), is(CARD.toString()));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void respondWith200_andRetrieveActiveTokens() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(DateTimeZone.UTC);
-        DateTime lastUsed = inserted.plusHours(1);
-        DateTime revoked = inserted.plusHours(2);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusHours(1);
+        ZonedDateTime revoked = inserted.plusHours(2);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
 
@@ -260,15 +254,15 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
         assertThat(firstToken.get("token_type"), is(CARD.toString()));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void respondWith200_andRetrieveActiveTokensIfNoQueryParamIsSpecified() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(UTC);
-        DateTime lastUsed = inserted.plusHours(1);
-        DateTime revoked = inserted.plusHours(2);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusHours(1);
+        ZonedDateTime revoked = inserted.plusHours(2);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
 
@@ -284,15 +278,15 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
         assertThat(firstToken.get("token_type"), is(CARD.toString()));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
 
     @Test
     public void respondWith200_andRetrieveActiveTokensIfUnknownQueryParamIsSpecified() throws Exception {
-        DateTime inserted = app.getDatabaseHelper().getCurrentTime().toDateTime(UTC);
-        DateTime lastUsed = inserted.plusHours(1);
-        DateTime revoked = inserted.plusHours(2);
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime lastUsed = inserted.plusHours(1);
+        ZonedDateTime revoked = inserted.plusHours(2);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
         List<Map<String, String>> retrievedTokens = getTokensFor(ACCOUNT_ID, "something")
@@ -307,8 +301,8 @@ public class PublicAuthResourceITest {
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
         assertThat(firstToken.get("token_type"), is(CARD.toString()));
-        assertThat(firstToken.get("last_used"), is(lastUsed.toString("dd MMM YYYY - HH:mm")));
-        assertThat(firstToken.get("issued_date"), is(inserted.toString("dd MMM YYYY - HH:mm")));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
 
     @Test
@@ -370,14 +364,14 @@ public class PublicAuthResourceITest {
     @Test
     public void respondWith200_ifUpdatingDescriptionOfExistingToken() throws Exception {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
-        DateTime nowFromDB = app.getDatabaseHelper().getCurrentTime().toDateTime(UTC);
+        ZonedDateTime nowFromDB = ZonedDateTime.now(ZoneOffset.UTC);
 
         updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(200)
                 .body("token_link", is(TOKEN_LINK))
                 .body("description", is(TOKEN_DESCRIPTION_2))
-                .body("issued_date", is(nowFromDB.toString("dd MMM YYYY - HH:mm")))
-                .body("last_used", is(nowFromDB.toString("dd MMM YYYY - HH:mm")))
+                .body("issued_date", is(nowFromDB.format(DATE_TIME_FORMAT)))
+                .body("last_used", is(nowFromDB.format(DATE_TIME_FORMAT)))
                 .body("created_by", is(CREATED_USER_NAME))
                 .body("token_type", is(CARD.toString()));
 
@@ -397,7 +391,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith404_butDoNotUpdateRevokedTokens() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, DateTime.now(), CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
         updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
@@ -437,7 +431,7 @@ public class PublicAuthResourceITest {
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
                 .statusCode(200)
-                .body("revoked", is(now.toString("dd MMM YYYY")));
+                .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
         assertThat(revokedInDb.isPresent(), is(true));
@@ -460,7 +454,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith404_whenRevokingTokenAlreadyRevoked() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, DateTime.now(), CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
                 .statusCode(404)
@@ -568,7 +562,7 @@ public class PublicAuthResourceITest {
                 .then();
     }
 
-    private Matcher<ReadableInstant> isCloseTo(DateTime now) {
+    private Matcher<ChronoZonedDateTime<?>> isCloseTo(ZonedDateTime now) {
         return both(greaterThan(now.minusSeconds(5))).and(lessThan(now.plusSeconds(5)));
     }
 

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.publicauth.utils;
 
-import io.dropwizard.jdbi.args.JodaDateTimeMapper;
+import io.dropwizard.jdbi.args.ZonedDateTimeMapper;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.StringMapper;
 import uk.gov.pay.publicauth.model.TokenPaymentType;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
@@ -13,6 +15,7 @@ import java.util.TimeZone;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
 
 public class DatabaseTestHelper {
+
     private DBI jdbi;
 
     public DatabaseTestHelper(DBI jdbi) {
@@ -20,29 +23,26 @@ public class DatabaseTestHelper {
     }
 
     public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, DateTime.now());
+        insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, DateTime revoked, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, DateTime.now());
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy) {
+        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, DateTime revoked, String createdBy, DateTime lastUsed) {
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed) {
         insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, lastUsed, CARD);
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, DateTime revoked, String createdBy, DateTime lastUsed, TokenPaymentType tokenPaymentType) {
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed, TokenPaymentType tokenPaymentType) {
         jdbi.withHandle(handle ->
         handle.insert("INSERT INTO tokens(token_hash, token_link, account_id, description, token_type, revoked, created_by, last_used) VALUES (?,?,?,?,?,(? at time zone 'utc'),?,(? at time zone 'utc'))",
-                tokenHash, randomTokenLink, accountId, description, tokenPaymentType, revoked, createdBy, lastUsed));
+                tokenHash, randomTokenLink, accountId, description, tokenPaymentType,
+                revoked, createdBy, lastUsed));
     }
 
-    public DateTime issueTimestampForAccount(String accountId) {
+    public ZonedDateTime issueTimestampForAccount(String accountId) {
         return getDateTimeColumn("issued", accountId);
-    }
-
-    public DateTime revokeTimestampForAccount(String accountId) {
-        return getDateTimeColumn("revoked", accountId);
     }
 
     public java.util.Optional<String> lookupColumnForTokenTable(String column, String idKey, String idValue) {
@@ -64,18 +64,11 @@ public class DatabaseTestHelper {
         return ret;
     }
 
-    public DateTime getDateTimeColumn(String column, String accountId) {
+    public ZonedDateTime getDateTimeColumn(String column, String accountId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT " + column + " FROM tokens WHERE account_id=:accountId")
                         .bind("accountId", accountId)
-                        .map(new JodaDateTimeMapper(Optional.of(TimeZone.getTimeZone("UTC"))))
-                        .first());
-    }
-
-    public DateTime getCurrentTime() {
-        return jdbi.withHandle(handle ->
-                handle.createQuery("SELECT (now() at time zone 'utc')")
-                        .map(new JodaDateTimeMapper(Optional.of(TimeZone.getTimeZone("UTC"))))
+                        .map(new ZonedDateTimeMapper(Optional.of(TimeZone.getTimeZone("UTC"))))
                         .first());
     }
 

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -72,4 +72,10 @@ public class DatabaseTestHelper {
                         .first());
     }
 
+    public ZonedDateTime getCurrentTime() {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT (now() at time zone 'utc')")
+                        .map(new ZonedDateTimeMapper(Optional.of(TimeZone.getTimeZone("UTC"))))
+                        .first());
+    }
 }


### PR DESCRIPTION
## WHAT
Use Java 8 time API instead of joda-time.
We are still getting the time from the database (which is not a pretty solution) to avoid clock skews which might happen.
We might ideally use the Java8 `Clock` so that we can mock it out in tests and use a fix timeframe, but that requires a broader change - publicauth needs some general refactoring anyway, so that could go on the list of todos.

 with @alexbishop1


