### PR TITLE
PP-3061 Add gateway account external ID

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/resources/CreateTokenParser.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/CreateTokenParser.java
@@ -1,0 +1,83 @@
+package uk.gov.pay.publicauth.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
+
+import java.util.Optional;
+
+import static java.util.UUID.randomUUID;
+import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
+import static uk.gov.pay.publicauth.model.TokenPaymentType.valueOf;
+
+class CreateTokenParser {
+    private static final String ACCOUNT_ID_FIELD = "account_id";
+    private static final String ACCOUNT_EXTERNAL_ID_FIELD = "account_external_id";
+    private static final String TOKEN_TYPE_FIELD = "token_type";
+    private static final String DESCRIPTION_FIELD = "description";
+    private static final String CREATED_BY_FIELD = "created_by";
+
+    public static class ParsedToken {
+        private String tokenLink;
+        private String accountId;
+        private String accountExternalId;
+        private String description;
+        private String createdBy;
+        private TokenPaymentType tokenPaymentType;
+
+        ParsedToken(String tokenLink, String accountId, String accountExternalId, String description, String createdBy, TokenPaymentType tokenPaymentType) {
+            this.tokenLink = tokenLink;
+            this.accountId = accountId;
+            this.accountExternalId = accountExternalId;
+            this.description = description;
+            this.createdBy = createdBy;
+            this.tokenPaymentType = tokenPaymentType;
+        }
+
+        public String getAccountId() {
+            return accountId;
+        }
+
+        public String getAccountExternalId() {
+            return accountExternalId;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getCreatedBy() {
+            return createdBy;
+        }
+
+        public TokenPaymentType getTokenPaymentType() {
+            return tokenPaymentType;
+        }
+
+        public String getTokenLink() {
+            return tokenLink;
+        }
+    }
+    public ParsedToken parse(JsonNode payload) {
+        String tokenLink = randomUUID().toString();
+
+        //todo check if this can be removed after updating selfservice and scripts
+        TokenPaymentType tokenPaymentType =
+                Optional.ofNullable(payload.get(TOKEN_TYPE_FIELD))
+                        .map(tokenType -> valueOf(tokenType.asText()))
+                        .orElse(CARD);
+
+        String accountExternalId =
+                Optional.ofNullable(payload.get(ACCOUNT_EXTERNAL_ID_FIELD))
+                        .map(JsonNode::asText)
+                        .filter(StringUtils::isNotBlank)
+                        .orElse(null);
+
+        return new ParsedToken(
+                tokenLink,
+                payload.get(ACCOUNT_ID_FIELD).asText(),
+                accountExternalId,
+                payload.get(DESCRIPTION_FIELD).asText(),
+                payload.get(CREATED_BY_FIELD).asText(), tokenPaymentType);
+    }
+}

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -82,4 +82,13 @@
 
         <addDefaultValue tableName="tokens" columnName="token_type" defaultValue="CARD"/>
     </changeSet>
+
+    <changeSet id="add account_external_id column to tokens table" author="">
+        <addColumn tableName="tokens">
+            <column name="account_external_id" type="varchar(36)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -9,6 +9,8 @@ import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
+import uk.gov.pay.publicauth.model.TokenStateFilterParam;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
 import java.time.ZoneOffset;
@@ -30,9 +32,12 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.DIRECT_DEBIT;
+import static uk.gov.pay.publicauth.model.TokenStateFilterParam.ACTIVE;
+import static uk.gov.pay.publicauth.model.TokenStateFilterParam.REVOKED;
 
 public class PublicAuthResourceITest {
 
@@ -42,12 +47,14 @@ public class PublicAuthResourceITest {
     private static final String BEARER_TOKEN = "testbearertoken";
     private static final String TOKEN_LINK = "123456789101112131415161718192021222";
     private static final String TOKEN_LINK_2 = "123456789101112131415161718192021223";
+
     private static final String HASHED_BEARER_TOKEN = BCrypt.hashpw(BEARER_TOKEN, SALT);
     private static final String HASHED_BEARER_TOKEN_2 = BCrypt.hashpw(BEARER_TOKEN + "2", SALT);
+    private static final String HASHED_BEARER_TOKEN_3 = BCrypt.hashpw(BEARER_TOKEN + "3", SALT);
     private static final String API_AUTH_PATH = "/v1/api/auth";
     private static final String FRONTEND_AUTH_PATH = "/v1/frontend/auth";
-    private static final String ACCOUNT_ID = "ACCOUNT-ID";
-    private static final String ACCOUNT_ID_2 = "ACCOUNT-ID-2";
+    private static final String ACCOUNT_ID = "111";
+    private static final String ACCOUNT_ID_2 = "222";
     private static final String TOKEN_DESCRIPTION = "TOKEN DESCRIPTION";
     private static final String TOKEN_DESCRIPTION_2 = "Token description 2";
     private static final String USER_EMAIL = "user@email.com";
@@ -59,16 +66,18 @@ public class PublicAuthResourceITest {
     public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
     private String validTokenPayload = new Gson().toJson(
             ImmutableMap.of("account_id", ACCOUNT_ID,
+                    "account_external_id", "null",
                     "description", TOKEN_DESCRIPTION,
                     "created_by", USER_EMAIL));
-    private String validTokenPayloadWithTokenType = new Gson().toJson(
+    private String validTokenPayloadWithTokenTypeAndExternalId = new Gson().toJson(
             ImmutableMap.of("account_id", ACCOUNT_ID,
+                    "account_external_id", "something",
                     "description", TOKEN_DESCRIPTION,
                     "token_type", DIRECT_DEBIT.toString(),
                     "created_by", USER_EMAIL));
     @Test
     public void respondWith200_whenAuthWithValidToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
         String apiKey = BEARER_TOKEN + encodedHmacValueOf(BEARER_TOKEN);
         tokenResponse(apiKey)
                 .statusCode(200)
@@ -79,7 +88,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith401_whenAuthWithRevokedToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION,
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION,
                 ZonedDateTime.now(ZoneOffset.UTC), CREATED_USER_NAME);
         String apiKey = BEARER_TOKEN + encodedHmacValueOf(BEARER_TOKEN);
         ZonedDateTime lastUsedPreAuth = app.getDatabaseHelper().getDateTimeColumn("last_used", ACCOUNT_ID);
@@ -120,11 +129,14 @@ public class PublicAuthResourceITest {
 
         Optional<String> newTokenType = app.getDatabaseHelper().lookupColumnForTokenTable("token_type", TOKEN_HASH_COLUMN, hashedToken);
         assertThat(newTokenType.get(), equalTo(CARD.toString()));
+
+        Optional<String> newTokenAccountExternalId = app.getDatabaseHelper().lookupColumnForTokenTable("account_external_id", TOKEN_HASH_COLUMN, hashedToken);
+        assertThat(newTokenAccountExternalId.isPresent(), is(false));
     }
 
     @Test
-    public void respondWith200_whenCreateAToken_ifProvidedAccountIdDescriptionAndTokenType() throws Exception {
-        String newToken = createTokenFor(validTokenPayloadWithTokenType)
+    public void respondWith200_whenCreateAToken_ifProvidedAccountIdDescriptionTokenTypeAndExternalId() throws Exception {
+        String newToken = createTokenFor(validTokenPayloadWithTokenTypeAndExternalId)
                 .statusCode(200)
                 .body("token", is(notNullValue()))
                 .extract().path("token");
@@ -135,25 +147,28 @@ public class PublicAuthResourceITest {
 
         Optional<String> newTokenType = app.getDatabaseHelper().lookupColumnForTokenTable("token_type", TOKEN_HASH_COLUMN, hashedToken);
         assertThat(newTokenType.get(), equalTo(DIRECT_DEBIT.toString()));
+
+        Optional<String> newTokenAccountExternalId = app.getDatabaseHelper().lookupColumnForTokenTable("account_external_id", TOKEN_HASH_COLUMN, hashedToken);
+        assertThat(newTokenAccountExternalId.get(), is("something"));
     }
 
     @Test
     public void respondWith400_ifAccountAndDescriptionAreMissing() throws Exception {
         createTokenFor("{}")
                 .statusCode(400)
-                .body("message", is("Missing fields: [account_id, description, created_by]"));
+                .body("message", is("Missing fields: [account_id, account_external_id, description, created_by]"));
     }
 
     @Test
     public void respondWith400_ifAccountIsMissing() throws Exception {
-        createTokenFor("{\"description\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\"}")
+        createTokenFor("{\"description\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\", \"account_external_id\": \"some-id\"}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [account_id]"));
     }
 
     @Test
     public void respondWith400_ifDescriptionIsMissing() throws Exception {
-        createTokenFor("{\"account_id\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\"}")
+        createTokenFor("{\"account_id\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\", \"account_external_id\": \"some-id\"}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [description]"));
     }
@@ -162,7 +177,7 @@ public class PublicAuthResourceITest {
     public void respondWith400_ifBodyIsMissing() throws Exception {
         createTokenFor("")
                 .statusCode(400)
-                .body("message", is("Missing fields: [account_id, description, created_by]"));
+                .body("message", is("Missing fields: [account_id, account_external_id, description, created_by]"));
     }
 
     @Test
@@ -173,14 +188,41 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith200_ifTokensHaveBeenIssuedForTheAccount() throws Exception {
+    public void respondWith200_ifTokensHaveBeenIssuedForACardAccount() throws Exception {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
+        ZonedDateTime revoked = inserted.plusHours(2);
 
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, CREATED_USER_NAME, lastUsed);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed, DIRECT_DEBIT);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, null, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
 
         List<Map<String, String>> retrievedTokens = getTokensFor(ACCOUNT_ID)
+                .statusCode(200)
+                .body("tokens", hasSize(1))
+                .extract().path("tokens");
+
+
+        Map<String, String> firstToken = retrievedTokens.get(0);
+        assertThat(firstToken.size(), is(6));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
+        assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
+        assertThat(firstToken.containsKey("revoked"), is(false));
+        assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
+        assertThat(firstToken.get("token_type"), is(CARD.toString()));
+        assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
+    }
+
+    @Test
+    public void respondWith200_ifTokensHaveBeenIssuedForADirectDebitAccount() throws Exception {
+        ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC
+        );
+        ZonedDateTime lastUsed = inserted.plusHours(1);
+        String accountExternalId = "blabla234";
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, accountExternalId, TOKEN_DESCRIPTION, null, CREATED_USER_NAME, lastUsed, DIRECT_DEBIT);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, accountExternalId, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed, DIRECT_DEBIT);
+
+        List<Map<String, String>> retrievedTokens = getTokensFor(accountExternalId, ACTIVE, DIRECT_DEBIT)
                 .statusCode(200)
                 .body("tokens", hasSize(2))
                 .extract().path("tokens");
@@ -203,7 +245,7 @@ public class PublicAuthResourceITest {
         assertThat(secondToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(secondToken.containsKey("revoked"), is(false));
         assertThat(secondToken.get("created_by"), is(CREATED_USER_NAME));
-        assertThat(secondToken.get("token_type"), is(CARD.toString()));
+        assertThat(secondToken.get("token_type"), is(DIRECT_DEBIT.toString()));
         assertThat(secondToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
         assertThat(secondToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
     }
@@ -214,9 +256,8 @@ public class PublicAuthResourceITest {
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
 
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
-
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, null, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
         List<Map<String, String>> retrievedTokens = getTokensFor(ACCOUNT_ID, "revoked")
                 .statusCode(200)
                 .body("tokens", hasSize(1))
@@ -235,25 +276,31 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith200_andRetrieveActiveTokens() throws Exception {
+    public void respondWith200_andRetrieveRevokedDirectDebitTokens() throws Exception {
+        String hashedBearerToken4 = BCrypt.hashpw(BEARER_TOKEN + "4", SALT);
+
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
 
-        List<Map<String, String>> retrievedTokens = getTokensFor(ACCOUNT_ID, "active")
+        String accountExternalId = "blabla234";
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, accountExternalId, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed, DIRECT_DEBIT);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, accountExternalId, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed, DIRECT_DEBIT);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_3, "123456789101112121415161718192021223", ACCOUNT_ID, null, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
+        app.getDatabaseHelper().insertAccount(hashedBearerToken4, "123456589101112131415161718192021223", ACCOUNT_ID, null, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
+        List<Map<String, String>> retrievedTokens = getTokensFor(accountExternalId, REVOKED, DIRECT_DEBIT)
                 .statusCode(200)
                 .body("tokens", hasSize(1))
                 .extract().path("tokens");
 
+
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
-        assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
-        assertThat(firstToken.containsKey("revoked"), is(false));
-        assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
-        assertThat(firstToken.get("token_type"), is(CARD.toString()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK));
+        assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
+        assertThat(firstToken.get("revoked"), is(revoked.format(DATE_TIME_FORMAT)));
+        assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME));
+        assertThat(firstToken.get("token_type"), is(DIRECT_DEBIT.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
         assertThat(firstToken.get("issued_date"), is(inserted.format(DATE_TIME_FORMAT)));
     }
@@ -263,8 +310,8 @@ public class PublicAuthResourceITest {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, null, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
 
         List<Map<String, String>> retrievedTokens = getTokensForWithNoQueryParam(ACCOUNT_ID)
                 .statusCode(200)
@@ -287,8 +334,8 @@ public class PublicAuthResourceITest {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, revoked, CREATED_USER_NAME, lastUsed);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID, null, TOKEN_DESCRIPTION_2, null, CREATED_USER_NAME2, lastUsed);
         List<Map<String, String>> retrievedTokens = getTokensFor(ACCOUNT_ID, "something")
                 .statusCode(200)
                 .body("tokens", hasSize(1))
@@ -307,7 +354,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith400_ifNotProvidingDescription_whenUpdating() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\"}")
                 .statusCode(400)
@@ -321,7 +368,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith400_ifNotProvidingTokenLink_whenUpdating() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         updateTokenDescription("{\"description\" : \"" + TOKEN_DESCRIPTION + "\"}")
                 .statusCode(400)
@@ -335,7 +382,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith400_ifNotProvidingTokenLinkNorDescription_whenUpdating() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         updateTokenDescription("{}")
                 .statusCode(400)
@@ -349,7 +396,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith400_ifNotProvidingBody_whenUpdating() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         updateTokenDescription("")
                 .statusCode(400)
@@ -363,7 +410,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith200_ifUpdatingDescriptionOfExistingToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
         ZonedDateTime nowFromDB = ZonedDateTime.now(ZoneOffset.UTC);
 
         updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
@@ -391,7 +438,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith404_butDoNotUpdateRevokedTokens() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
         updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
@@ -403,7 +450,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith400_ifNotProvidingBody_whenRevokingAToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "")
                 .statusCode(400)
@@ -415,7 +462,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith400_ifProvidingEmptyBody_whenRevokingAToken() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "{}")
                 .statusCode(400)
@@ -427,7 +474,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith200_whenSingleTokenIsRevoked() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
                 .statusCode(200)
@@ -439,8 +486,8 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith404_whenRevokingTokenForAnotherAccount() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID_2, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID_2, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK_2 + "\"}")
                 .statusCode(404)
@@ -454,7 +501,7 @@ public class PublicAuthResourceITest {
 
     @Test
     public void respondWith404_whenRevokingTokenAlreadyRevoked() throws Exception {
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
                 .statusCode(404)
@@ -485,7 +532,7 @@ public class PublicAuthResourceITest {
     @Test
     public void respondWith401_whenAuthHeaderIsBasicEvenWithValidToken() throws Exception {
 
-        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, null, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         String apiKey = BEARER_TOKEN + encodedHmacValueOf(BEARER_TOKEN);
 
@@ -517,14 +564,6 @@ public class PublicAuthResourceITest {
                 .then();
     }
 
-    private ValidatableResponse getTokensFor(String accountId, String tokenState) {
-        return given().port(app.getLocalPort())
-                .accept(JSON)
-                .param("state", tokenState)
-                .get(FRONTEND_AUTH_PATH + "/" + accountId)
-                .then();
-    }
-
     private ValidatableResponse getTokensForWithNoQueryParam(String accountId) {
         return given().port(app.getLocalPort())
                 .accept(JSON)
@@ -536,6 +575,22 @@ public class PublicAuthResourceITest {
         return getTokensFor(accountId, "active");
     }
 
+    private ValidatableResponse getTokensFor(String accountId, String tokenState) {
+        return given().port(app.getLocalPort())
+                .accept(JSON)
+                .param("state", tokenState)
+                .get(FRONTEND_AUTH_PATH + "/" + accountId)
+                .then();
+    }
+
+    private ValidatableResponse getTokensFor(String accountId, TokenStateFilterParam tokenState, TokenPaymentType paymentType) {
+        return given().port(app.getLocalPort())
+                .accept(JSON)
+                .param("state", tokenState)
+                .param("type", paymentType)
+                .get(FRONTEND_AUTH_PATH + "/" + accountId)
+                .then();
+    }
     private ValidatableResponse updateTokenDescription(String body) {
         return given().port(app.getLocalPort())
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -66,7 +66,6 @@ public class PublicAuthResourceITest {
     public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
     private String validTokenPayload = new Gson().toJson(
             ImmutableMap.of("account_id", ACCOUNT_ID,
-                    "account_external_id", "null",
                     "description", TOKEN_DESCRIPTION,
                     "created_by", USER_EMAIL));
     private String validTokenPayloadWithTokenTypeAndExternalId = new Gson().toJson(
@@ -156,7 +155,7 @@ public class PublicAuthResourceITest {
     public void respondWith400_ifAccountAndDescriptionAreMissing() throws Exception {
         createTokenFor("{}")
                 .statusCode(400)
-                .body("message", is("Missing fields: [account_id, account_external_id, description, created_by]"));
+                .body("message", is("Missing fields: [account_id, description, created_by]"));
     }
 
     @Test
@@ -177,7 +176,7 @@ public class PublicAuthResourceITest {
     public void respondWith400_ifBodyIsMissing() throws Exception {
         createTokenFor("")
                 .statusCode(400)
-                .body("message", is("Missing fields: [account_id, account_external_id, description, created_by]"));
+                .body("message", is("Missing fields: [account_id, description, created_by]"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/publicauth/resources/CreateTokenParserTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/resources/CreateTokenParserTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.publicauth.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class CreateTokenParserTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    CreateTokenParser createTokenParser = new CreateTokenParser();
+
+    @Test
+    public void shouldParseToken() throws IOException {
+        JsonNode json = objectMapper.readTree("{"
+                + "\"account_id\": \"12345\",\n"
+                + "\"account_external_id\": \"abc123\",\n"
+                + "\"token_type\": \"DIRECT_DEBIT\",\n"
+                + "\"description\": \"Description\",\n"
+                + "\"created_by\": \"Alex\"\n"
+                + "}");
+
+        CreateTokenParser.ParsedToken parsedToken = createTokenParser.parse(json);
+
+        assertThat(parsedToken.getAccountId(), is("12345"));
+        assertThat(parsedToken.getAccountExternalId(), is("abc123"));
+        assertThat(parsedToken.getTokenPaymentType(), is(TokenPaymentType.DIRECT_DEBIT));
+        assertThat(parsedToken.getDescription(), is("Description"));
+        assertThat(parsedToken.getCreatedBy(), is("Alex"));
+    }
+
+    @Test
+    public void shouldSetTokenTypeToCardIfNotIncluded() throws IOException {
+        JsonNode json = objectMapper.readTree("{"
+                + "\"account_id\": \"12345\",\n"
+                + "\"account_external_id\": \"abc123\",\n"
+                + "\"description\": \"Description\",\n"
+                + "\"created_by\": \"Alex\"\n"
+                + "}");
+
+        CreateTokenParser.ParsedToken parsedToken = createTokenParser.parse(json);
+
+        assertThat(parsedToken.getTokenPaymentType(), is(TokenPaymentType.CARD));
+    }
+
+    @Test
+    public void shouldNotHaveAccountExternalIdIfNotIncluded() throws IOException {
+        JsonNode json = objectMapper.readTree("{"
+                + "\"account_id\": \"12345\",\n"
+                + "\"token_type\": \"DIRECT_DEBIT\",\n"
+                + "\"description\": \"Description\",\n"
+                + "\"created_by\": \"Alex\"\n"
+                + "}");
+
+        CreateTokenParser.ParsedToken parsedToken = createTokenParser.parse(json);
+
+        assertThat(parsedToken.getAccountExternalId(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldNotHaveAccountExternalIdIfSentAsEmptyString() throws IOException {
+        JsonNode json = objectMapper.readTree("{"
+                + "\"account_id\": \"12345\",\n"
+                + "\"account_external_id\": \"\",\n"
+                + "\"token_type\": \"DIRECT_DEBIT\",\n"
+                + "\"description\": \"Description\",\n"
+                + "\"created_by\": \"Alex\"\n"
+                + "}");
+
+        CreateTokenParser.ParsedToken parsedToken = createTokenParser.parse(json);
+
+        assertThat(parsedToken.getAccountExternalId(), is(nullValue()));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.publicauth.utils;
 
 import io.dropwizard.jdbi.args.ZonedDateTimeMapper;
-import org.joda.time.DateTime;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.StringMapper;
 import uk.gov.pay.publicauth.model.TokenPaymentType;
@@ -22,22 +21,22 @@ public class DatabaseTestHelper {
         this.jdbi = jdbi;
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId,  String accountExternalId, String description, String createdBy) {
+        insertAccount(tokenHash, randomTokenLink, accountId, null, description, null, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId,  String accountExternalId, String description, ZonedDateTime revoked, String createdBy) {
+        insertAccount(tokenHash, randomTokenLink, accountId, null, description, revoked, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, lastUsed, CARD);
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String accountExternalId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed) {
+        insertAccount(tokenHash, randomTokenLink, accountId, null, description, revoked, createdBy, lastUsed, CARD);
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed, TokenPaymentType tokenPaymentType) {
+    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String accountExternalId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed, TokenPaymentType tokenPaymentType) {
         jdbi.withHandle(handle ->
-        handle.insert("INSERT INTO tokens(token_hash, token_link, account_id, description, token_type, revoked, created_by, last_used) VALUES (?,?,?,?,?,(? at time zone 'utc'),?,(? at time zone 'utc'))",
-                tokenHash, randomTokenLink, accountId, description, tokenPaymentType,
+        handle.insert("INSERT INTO tokens(token_hash, token_link, account_id, account_external_id, description, token_type, revoked, created_by, last_used) VALUES (?,?,?,?,?,?,(? at time zone 'utc'),?,(? at time zone 'utc'))",
+                tokenHash, randomTokenLink, accountId, accountExternalId, description, tokenPaymentType,
                 revoked, createdBy, lastUsed));
     }
 
@@ -56,7 +55,7 @@ public class DatabaseTestHelper {
 
     public Map<String, Object> getTokenByHash(String tokenHash) {
         Map<String, Object> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT token_id, token_type, token_hash, account_id, issued, revoked, token_link, description, created_by " +
+                h.createQuery("SELECT token_id, token_type, token_hash, account_id, account_external_id, issued, revoked, token_link, description, created_by " +
                         "FROM tokens t " +
                         "WHERE token_hash = :token_hash")
                         .bind("token_hash", tokenHash)
@@ -78,4 +77,5 @@ public class DatabaseTestHelper {
                         .map(new ZonedDateTimeMapper(Optional.of(TimeZone.getTimeZone("UTC"))))
                         .first());
     }
+
 }


### PR DESCRIPTION
 - We are currently using the internal `gateway_account_id` for publicauth's paths
   This has worked fine until we added direct debit gateway accounts. As we store
   gateway accounts in two different connectors / dbs, there will be clashes in account ids
 - Using external account ids will avoid this issue. For now, as credit card account don't have
   any external id, we are going to support both accounts.
 - If the `<accountId>` is numeric, it's an internal account id and we will search in the db for
   CC tokens. If it's alphanumeric, it's an external account id and we will search for DD tokens.

This piece of logic will be removed once we backfill the data and assign an external id to all
existing card gateway accounts in cc connector.

with @simad 