### PR TITLE
PP-3095 Add pipeline stage to deploy to ECS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,8 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("publicauth", "test", null, true)
+        deploy("publicauth", "test", null, false, false)
+        deployEcs("publicauth", "test", null, true, true)
       }
     }
   }


### PR DESCRIPTION
## WHAT
With publicauth ready for deployment into ECS, this adds a pipeline stage to the Jenkinsfile that will deploy to ECS as well as via the legacy method.

