### PR TITLE
PP-3350 Upgrade dropwizard to 1.2.x for Public Auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>pay-publicauth</artifactId>
 
     <properties>
-        <dropwizard.version>1.0.6</dropwizard.version>
+        <dropwizard.version>1.2.2</dropwizard.version>
         <docker-client.version>8.9.2</docker-client.version>
     </properties>
     <dependencies>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.10</version>
+            <version>2.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.mindrot</groupId>
@@ -84,21 +84,17 @@
             <artifactId>metrics-graphite</artifactId>
             <version>3.1.2</version>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>2.25.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-jaxb</artifactId>
-            <version>2.25.1</version>
-        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.15.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>


### PR DESCRIPTION
# WHAT

* Upgraded Dropwizard to version 1.2.2:
	* Since version 1.1.0, Dropwizard dropped dependency to `org.mockito`intentional. The Mockito dependency was only accidentally Maven's "compile" scope and has since moved into the correct "test" scope. See https://github.com/dropwizard/dropwizard/pull/1851 for details. Since Dropwizard itself has no dependency on Mockito except for its internal tests, a dependency to the latest stable version 2.15.0 had to be added to the project explicitly.  


* Removed explicit dependency of jersey version 2.25.1 which is not anymore needed since Dropwizard 1.2.2 already ships with that version. Note: jersey 2.25.1 is reported to have a medium vulnerability “XML Entity Expansion (XEE)” which has not yet been addressed in any subsequent version.

* Pinned Jackson to version 2.9.4 which has a fix to address a vulnerability detected in version 2.9.1 which would otherwise be pulled by Dropwizard 1.2.2.

* Note: Hibernate Validator version 5.4.1.Final pulled down with Dropwizard 1.2.2 is reported to have a “Privilege Escalation” vulnerability issue. Upgrading to 6.0.7.Final as recommended breaks the build due to api incompatibilities. The security issue has to do with Java Security manager which is not been used therefore we are safe to leave it as it is. 