### PR TITLE
BAU - Add dropwizard metrics for each endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.publicauth.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
@@ -63,6 +64,7 @@ public class PublicAuthResource {
     }
 
     @Path("/v1/api/auth")
+    @Timed
     @Produces(APPLICATION_JSON)
     @GET
     public Response authenticate(@Auth Token token) {
@@ -75,6 +77,7 @@ public class PublicAuthResource {
     }
 
     @Path("/v1/frontend/auth")
+    @Timed
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     @POST
@@ -99,6 +102,7 @@ public class PublicAuthResource {
     }
 
     @Path("/v1/frontend/auth/{accountId}")
+    @Timed
     @Produces(APPLICATION_JSON)
     @GET
     public Response getIssuedTokensForAccount(@PathParam("accountId") String accountId, @QueryParam("state") TokenStateFilterParam state) {
@@ -108,6 +112,7 @@ public class PublicAuthResource {
     }
 
     @Path("/v1/frontend/auth")
+    @Timed
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @PUT
@@ -130,6 +135,7 @@ public class PublicAuthResource {
     }
 
     @Path("/v1/frontend/auth/{accountId}")
+    @Timed
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @DELETE


### PR DESCRIPTION
We'd like to have dropwizard metrics to measure the response times for each of our endpoints.

The metrics added by dropwizard for each endpoint are something like this:

```
"uk.gov.pay.publicauth.resources.PublicAuthResource.createTokenForAccount": {
      "count": 89,
      "max": 1.610663041,
      "mean": 0.6122510077877983,
      "min": 0.131364021,
      "p50": 0.6673303650000001,
      "p75": 0.7761138350000001,
      "p95": 1.194686932,
      "p98": 1.21974942,
      "p99": 1.21974942,
      "p999": 1.3611836130000001,
      "stddev": 0.3178064275553258,
      "m15_rate": 0.060280191333312604,
      "m1_rate": 0.033173111988631133,
      "m5_rate": 0.08651689402500556,
      "mean_rate": 0.0663933806675867,
      "duration_units": "seconds",
      "rate_units": "calls/second"
    }
```


