### PR TITLE
PP-3816 Allow revoking a token by token_hash

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/auth/Token.java
+++ b/src/main/java/uk/gov/pay/publicauth/auth/Token.java
@@ -1,17 +1,19 @@
 package uk.gov.pay.publicauth.auth;
 
+import uk.gov.pay.publicauth.model.TokenHash;
+
 import java.security.Principal;
 
 public class Token implements Principal {
 
-    private final String name;
+    private final TokenHash name;
 
-    public Token(String name) {
+    public Token(TokenHash name) {
         this.name = name;
     }
 
     @Override
     public String getName() {
-        return name;
+        return name.getValue();
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/auth/TokenAuthenticator.java
+++ b/src/main/java/uk/gov/pay/publicauth/auth/TokenAuthenticator.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.publicauth.auth;
 
-import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import uk.gov.pay.publicauth.service.TokenService;
 
@@ -15,7 +14,7 @@ public class TokenAuthenticator implements Authenticator<String, Token> {
     }
 
     @Override
-    public Optional<Token> authenticate(String bearerToken) throws AuthenticationException {
+    public Optional<Token> authenticate(String bearerToken) {
         return tokenService.extractEncryptedTokenFrom(bearerToken);
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenHash.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenHash.java
@@ -2,7 +2,7 @@ package uk.gov.pay.publicauth.model;
 
 import java.util.Objects;
 
-public class TokenHash implements TokenIdentifier {
+public class TokenHash {
     private final String tokenHash;
 
     private TokenHash (String tokenHash) {
@@ -32,13 +32,7 @@ public class TokenHash implements TokenIdentifier {
     public String toString() {
         return "token_hash";
     }
-
-    @Override
-    public String getColumnName() {
-        return "token_hash";
-    }
-
-    @Override
+    
     public String getValue() {
         return tokenHash;
     }

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenHash.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenHash.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.publicauth.model;
+
+import java.util.Objects;
+
+public class TokenHash implements TokenIdentifier {
+    private final String tokenHash;
+
+    private TokenHash (String tokenHash) {
+        this.tokenHash = Objects.requireNonNull(tokenHash);
+    }
+
+    public static TokenHash of(String tokenHash) {
+        return new TokenHash (tokenHash);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == TokenHash .class) {
+            TokenHash that = (TokenHash) other;
+            return this.tokenHash.equals(that.tokenHash);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return tokenHash.hashCode();
+    }
+
+    //make sure we never serialise the token value
+    @Override
+    public String toString() {
+        return "token_hash";
+    }
+
+    @Override
+    public String getColumnName() {
+        return "token_hash";
+    }
+
+    @Override
+    public String getValue() {
+        return tokenHash;
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenIdentifier.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenIdentifier.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.publicauth.model;
+
+public interface TokenIdentifier {
+    String getColumnName();
+    String getValue();
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenIdentifier.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenIdentifier.java
@@ -1,6 +1,0 @@
-package uk.gov.pay.publicauth.model;
-
-public interface TokenIdentifier {
-    String getColumnName();
-    String getValue();
-}

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenLink.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenLink.java
@@ -2,7 +2,7 @@ package uk.gov.pay.publicauth.model;
 
 import java.util.Objects;
 
-public class TokenLink implements TokenIdentifier {
+public class TokenLink {
     private final String tokenLink;
 
     private TokenLink(String tokenLink) {
@@ -32,12 +32,6 @@ public class TokenLink implements TokenIdentifier {
         return "token_link " + tokenLink;
     }
 
-    @Override
-    public String getColumnName() {
-        return "token_link";
-    }
-
-    @Override
     public String getValue() {
         return tokenLink;
     }

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenLink.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenLink.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.publicauth.model;
+
+import java.util.Objects;
+
+public class TokenLink implements TokenIdentifier {
+    private final String tokenLink;
+
+    private TokenLink(String tokenLink) {
+        this.tokenLink = Objects.requireNonNull(tokenLink);
+    }
+
+    public static TokenLink of(String tokenLink) {
+        return new TokenLink(tokenLink);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == TokenLink.class) {
+            TokenLink that = (TokenLink) other;
+            return this.tokenLink.equals(that.tokenLink);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return tokenLink.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "token_link " + tokenLink;
+    }
+
+    @Override
+    public String getColumnName() {
+        return "token_link";
+    }
+
+    @Override
+    public String getValue() {
+        return tokenLink;
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/Tokens.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/Tokens.java
@@ -2,16 +2,16 @@ package uk.gov.pay.publicauth.model;
 
 public class Tokens {
 
-    private final String hashedToken;
+    private final TokenHash hashedToken;
 
     private final String apiKey;
 
-    public Tokens(String hashedToken, String apiKey) {
+    public Tokens(TokenHash hashedToken, String apiKey) {
         this.hashedToken = hashedToken;
         this.apiKey = apiKey;
     }
 
-    public String getHashedToken() {
+    public TokenHash getHashedToken() {
         return hashedToken;
     }
 

--- a/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.publicauth.app.config.TokensConfiguration;
 import uk.gov.pay.publicauth.auth.Token;
+import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.Tokens;
 
 import java.util.Optional;
@@ -50,8 +51,8 @@ public class TokenService {
         return extractAndEncryptTokenFrom(apiKey);
     }
 
-    private String encrypt(String token) {
-        return BCrypt.hashpw(token, encryptDBSalt);
+    private TokenHash encrypt(String token) {
+        return TokenHash.of(BCrypt.hashpw(token, encryptDBSalt));
     }
 
     private String createApiKey(String token) {

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoTest.java
@@ -250,7 +250,7 @@ public class AuthTokenDaoTest {
     }
 
     @Test
-    public void shouldRevokeASingleTokenByToken() {
+    public void shouldRevokeASingleTokenByTokenHash() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
         Optional<String> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_HASH);

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -421,7 +421,7 @@ public class PublicAuthResourceITest {
 
         revokeSingleToken(ACCOUNT_ID, "{}")
                 .statusCode(400)
-                .body("message", is("At least one of these fields is missing: [token_link, token_hash]"));
+                .body("message", is("At least one of these fields must be present: [token_link, token_hash]"));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
         assertThat(revokedInDb.isPresent(), is(false));

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceITest.java
@@ -9,6 +9,8 @@ import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mindrot.jbcrypt.BCrypt;
+import uk.gov.pay.publicauth.model.TokenHash;
+import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
 import java.time.ZoneOffset;
@@ -40,10 +42,10 @@ public class PublicAuthResourceITest {
 
     private static final String SALT = "$2a$10$IhaXo6LIBhKIWOiGpbtPOu";
     private static final String BEARER_TOKEN = "testbearertoken";
-    private static final String TOKEN_LINK = "123456789101112131415161718192021222";
-    private static final String TOKEN_LINK_2 = "123456789101112131415161718192021223";
-    private static final String HASHED_BEARER_TOKEN = BCrypt.hashpw(BEARER_TOKEN, SALT);
-    private static final String HASHED_BEARER_TOKEN_2 = BCrypt.hashpw(BEARER_TOKEN + "2", SALT);
+    private static final TokenLink TOKEN_LINK = TokenLink.of("123456789101112131415161718192021222");
+    private static final TokenLink TOKEN_LINK_2 = TokenLink.of("123456789101112131415161718192021223");
+    private static final TokenHash HASHED_BEARER_TOKEN = TokenHash.of(BCrypt.hashpw(BEARER_TOKEN, SALT));
+    private static final TokenHash HASHED_BEARER_TOKEN_2 = TokenHash.of(BCrypt.hashpw(BEARER_TOKEN + "2", SALT));
     private static final String API_AUTH_PATH = "/v1/api/auth";
     private static final String FRONTEND_AUTH_PATH = "/v1/frontend/auth";
     private static final String ACCOUNT_ID = "ACCOUNT-ID";
@@ -67,7 +69,7 @@ public class PublicAuthResourceITest {
                     "token_type", DIRECT_DEBIT.toString(),
                     "created_by", USER_EMAIL));
     @Test
-    public void respondWith200_whenAuthWithValidToken() throws Exception {
+    public void respondWith200_whenAuthWithValidToken() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
         String apiKey = BEARER_TOKEN + encodedHmacValueOf(BEARER_TOKEN);
         tokenResponse(apiKey)
@@ -78,7 +80,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith401_whenAuthWithRevokedToken() throws Exception {
+    public void respondWith401_whenAuthWithRevokedToken() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION,
                 ZonedDateTime.now(ZoneOffset.UTC), CREATED_USER_NAME);
         String apiKey = BEARER_TOKEN + encodedHmacValueOf(BEARER_TOKEN);
@@ -91,14 +93,14 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith401_whenAuthWithNonExistentToken() throws Exception {
+    public void respondWith401_whenAuthWithNonExistentToken() {
         String apiKey = BEARER_TOKEN + encodedHmacValueOf(BEARER_TOKEN);
         tokenResponse(apiKey)
                 .statusCode(401);
     }
 
     @Test
-    public void respondWith200_whenCreateAToken_ifProvidedBothAccountIdAndDescription() throws Exception {
+    public void respondWith200_whenCreateAToken_ifProvidedBothAccountIdAndDescription() {
         String newToken = createTokenFor(validTokenPayload)
                 .statusCode(200)
                 .body("token", is(notNullValue()))
@@ -123,7 +125,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith200_whenCreateAToken_ifProvidedAccountIdDescriptionAndTokenType() throws Exception {
+    public void respondWith200_whenCreateAToken_ifProvidedAccountIdDescriptionAndTokenType() {
         String newToken = createTokenFor(validTokenPayloadWithTokenType)
                 .statusCode(200)
                 .body("token", is(notNullValue()))
@@ -138,42 +140,42 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith400_ifAccountAndDescriptionAreMissing() throws Exception {
+    public void respondWith400_ifAccountAndDescriptionAreMissing() {
         createTokenFor("{}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [account_id, description, created_by]"));
     }
 
     @Test
-    public void respondWith400_ifAccountIsMissing() throws Exception {
+    public void respondWith400_ifAccountIsMissing() {
         createTokenFor("{\"description\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\"}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [account_id]"));
     }
 
     @Test
-    public void respondWith400_ifDescriptionIsMissing() throws Exception {
+    public void respondWith400_ifDescriptionIsMissing() {
         createTokenFor("{\"account_id\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\"}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [description]"));
     }
 
     @Test
-    public void respondWith400_ifBodyIsMissing() throws Exception {
+    public void respondWith400_ifBodyIsMissing() {
         createTokenFor("")
                 .statusCode(400)
-                .body("message", is("Missing fields: [account_id, description, created_by]"));
+                .body("message", is("Body cannot be empty"));
     }
 
     @Test
-    public void respondWith200_andEmptyList_ifNoTokensHaveBeenIssuedForTheAccount() throws Exception {
+    public void respondWith200_andEmptyList_ifNoTokensHaveBeenIssuedForTheAccount() {
         getTokensFor(ACCOUNT_ID)
                 .statusCode(200)
                 .body("tokens", hasSize(0));
     }
 
     @Test
-    public void respondWith200_ifTokensHaveBeenIssuedForTheAccount() throws Exception {
+    public void respondWith200_ifTokensHaveBeenIssuedForTheAccount() {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
 
@@ -189,7 +191,7 @@ public class PublicAuthResourceITest {
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
         assertThat(firstToken.size(), is(6));
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -199,7 +201,7 @@ public class PublicAuthResourceITest {
 
         Map<String, String> secondToken = retrievedTokens.get(1);
         assertThat(secondToken.size(), is(6));
-        assertThat(secondToken.get("token_link"), is(TOKEN_LINK));
+        assertThat(secondToken.get("token_link"), is(TOKEN_LINK.getValue()));
         assertThat(secondToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(secondToken.containsKey("revoked"), is(false));
         assertThat(secondToken.get("created_by"), is(CREATED_USER_NAME));
@@ -209,7 +211,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith200_andRetrieveRevokedTokens() throws Exception {
+    public void respondWith200_andRetrieveRevokedTokens() {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
@@ -225,7 +227,7 @@ public class PublicAuthResourceITest {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK.getValue()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(firstToken.get("revoked"), is(revoked.format(DATE_TIME_FORMAT)));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME));
@@ -235,7 +237,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith200_andRetrieveActiveTokens() throws Exception {
+    public void respondWith200_andRetrieveActiveTokens() {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
@@ -249,7 +251,7 @@ public class PublicAuthResourceITest {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -259,7 +261,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith200_andRetrieveActiveTokensIfNoQueryParamIsSpecified() throws Exception {
+    public void respondWith200_andRetrieveActiveTokensIfNoQueryParamIsSpecified() {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
@@ -273,7 +275,7 @@ public class PublicAuthResourceITest {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -283,7 +285,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith200_andRetrieveActiveTokensIfUnknownQueryParamIsSpecified() throws Exception {
+    public void respondWith200_andRetrieveActiveTokensIfUnknownQueryParamIsSpecified() {
         ZonedDateTime inserted = ZonedDateTime.now(ZoneOffset.UTC);
         ZonedDateTime lastUsed = inserted.plusHours(1);
         ZonedDateTime revoked = inserted.plusHours(2);
@@ -296,7 +298,7 @@ public class PublicAuthResourceITest {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -306,176 +308,188 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith400_ifNotProvidingDescription_whenUpdating() throws Exception {
+    public void respondWith400_ifNotProvidingDescription_whenUpdating() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\"}")
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [description]"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK);
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
     }
 
     @Test
-    public void respondWith400_ifNotProvidingTokenLink_whenUpdating() throws Exception {
+    public void respondWith400_ifNotProvidingTokenLink_whenUpdating() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         updateTokenDescription("{\"description\" : \"" + TOKEN_DESCRIPTION + "\"}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [token_link]"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK);
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
     }
 
     @Test
-    public void respondWith400_ifNotProvidingTokenLinkNorDescription_whenUpdating() throws Exception {
+    public void respondWith400_ifNotProvidingTokenLinkNorDescription_whenUpdating() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         updateTokenDescription("{}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [token_link, description]"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK);
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
     }
 
     @Test
-    public void respondWith400_ifNotProvidingBody_whenUpdating() throws Exception {
+    public void respondWith400_ifNotProvidingBody_whenUpdating() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         updateTokenDescription("")
                 .statusCode(400)
-                .body("message", is("Missing fields: [token_link, description]"));
+                .body("message", is("Body cannot be empty"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK);
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
     }
 
     @Test
-    public void respondWith200_ifUpdatingDescriptionOfExistingToken() throws Exception {
+    public void respondWith200_ifUpdatingDescriptionOfExistingToken() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
         ZonedDateTime nowFromDB = ZonedDateTime.now(ZoneOffset.UTC);
 
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(200)
-                .body("token_link", is(TOKEN_LINK))
+                .body("token_link", is(TOKEN_LINK.getValue()))
                 .body("description", is(TOKEN_DESCRIPTION_2))
                 .body("issued_date", is(nowFromDB.format(DATE_TIME_FORMAT)))
                 .body("last_used", is(nowFromDB.format(DATE_TIME_FORMAT)))
                 .body("created_by", is(CREATED_USER_NAME))
                 .body("token_type", is(CARD.toString()));
 
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION_2));
     }
 
     @Test
-    public void respondWith404_ifUpdatingDescriptionOfNonExistingToken() throws Exception {
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
+    public void respondWith404_ifUpdatingDescriptionOfNonExistingToken() {
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
                 .body("message", is("Could not update description of token with token_link " + TOKEN_LINK));
 
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
         assertThat(descriptionInDb.isPresent(), is(false));
     }
 
     @Test
-    public void respondWith404_butDoNotUpdateRevokedTokens() throws Exception {
+    public void respondWith404_butDoNotUpdateRevokedTokens() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
                 .body("message", is("Could not update description of token with token_link " + TOKEN_LINK));
 
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK);
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
     }
 
     @Test
-    public void respondWith400_ifNotProvidingBody_whenRevokingAToken() throws Exception {
+    public void respondWith400_ifNotProvidingBody_whenRevokingAToken() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "")
                 .statusCode(400)
-                .body("message", is("Missing fields: [token_link]"));
+                .body("message", is("Body cannot be empty"));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
         assertThat(revokedInDb.isPresent(), is(false));
     }
 
     @Test
-    public void respondWith400_ifProvidingEmptyBody_whenRevokingAToken() throws Exception {
+    public void respondWith400_ifProvidingEmptyBody_whenRevokingAToken() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
         revokeSingleToken(ACCOUNT_ID, "{}")
                 .statusCode(400)
-                .body("message", is("Missing fields: [token_link]"));
+                .body("message", is("At least one of these fields is missing: [token_link, token_hash]"));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
         assertThat(revokedInDb.isPresent(), is(false));
     }
 
     @Test
-    public void respondWith200_whenSingleTokenIsRevoked() throws Exception {
+    public void respondWith200_whenSingleTokenIsRevokedByTokenLink() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
                 .statusCode(200)
                 .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
         assertThat(revokedInDb.isPresent(), is(true));
     }
 
     @Test
-    public void respondWith404_whenRevokingTokenForAnotherAccount() throws Exception {
+    public void respondWith200_whenSingleTokenIsRevokedByTokenHash() {
+        app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
+
+        revokeSingleToken(ACCOUNT_ID, "{\"token_hash\" : \"" + HASHED_BEARER_TOKEN.getValue() + "\"}")
+                .statusCode(200)
+                .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
+
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        assertThat(revokedInDb.isPresent(), is(true));
+    }
+
+    @Test
+    public void respondWith404_whenRevokingTokenForAnotherAccount() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID_2, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK_2 + "\"}")
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK_2.getValue() + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK_2));
+                .body("message", is("Could not revoke token with " + TOKEN_LINK_2));
 
-        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
+        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
         assertThat(token1RevokedInDb.isPresent(), is(false));
-        Optional<String> token2RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK_2);
+        Optional<String> token2RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK_2.getValue());
         assertThat(token2RevokedInDb.isPresent(), is(false));
     }
 
     @Test
-    public void respondWith404_whenRevokingTokenAlreadyRevoked() throws Exception {
+    public void respondWith404_whenRevokingTokenAlreadyRevoked() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK ));
+                .body("message", is("Could not revoke token with " + TOKEN_LINK ));
 
-        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK);
+        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
         assertThat(token1RevokedInDb.isPresent(), is(true));
     }
 
     @Test
-    public void respondWith404_whenTokenDoesNotExist() throws Exception {
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK + "\"}")
+    public void respondWith404_whenTokenDoesNotExist() {
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK));
+                .body("message", is("Could not revoke token with " + TOKEN_LINK));
 
-        Optional<String> tokenLinkdInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK);
+        Optional<String> tokenLinkdInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
         assertThat(tokenLinkdInDb.isPresent(), is(false));
     }
 
     @Test
-    public void respondWith401_whenAuthHeaderIsMissing() throws Exception {
+    public void respondWith401_whenAuthHeaderIsMissing() {
         given().port(app.getLocalPort())
                 .get(API_AUTH_PATH)
                 .then()
@@ -483,7 +497,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void respondWith401_whenAuthHeaderIsBasicEvenWithValidToken() throws Exception {
+    public void respondWith401_whenAuthHeaderIsBasicEvenWithValidToken() {
 
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
@@ -497,7 +511,7 @@ public class PublicAuthResourceITest {
     }
 
     @Test
-    public void shouldNotStoreTheTokenInThePlain() throws Exception {
+    public void shouldNotStoreTheTokenInThePlain() {
         String newToken = createTokenFor(validTokenPayload)
                 .statusCode(200)
                 .extract()

--- a/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
@@ -9,6 +9,7 @@ import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.publicauth.app.config.TokensConfiguration;
 import uk.gov.pay.publicauth.auth.Token;
+import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.Tokens;
 
 import java.util.List;
@@ -46,11 +47,11 @@ public class TokenServiceTest {
 
         Tokens tokens = tokenService.issueTokens();
 
-        String hashedToken = tokens.getHashedToken();
+        TokenHash hashedToken = tokens.getHashedToken();
 
         assertThat(hashedToken, is(notNullValue()));
-        assertThat(hashedToken.length(), is(60));
-        assertThat(hashedToken, startsWith(EXPECTED_SALT));
+        assertThat(hashedToken.getValue().length(), is(60));
+        assertThat(hashedToken.getValue(), startsWith(EXPECTED_SALT));
     }
 
     @Test
@@ -87,7 +88,7 @@ public class TokenServiceTest {
 
         String plainToken = apiKey.substring(0, tokenEnd);
 
-        assertThat(BCrypt.hashpw(plainToken, EXPECTED_SALT), is(tokens.getHashedToken()));
+        assertThat(BCrypt.hashpw(plainToken, EXPECTED_SALT), is(tokens.getHashedToken().getValue()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.publicauth.utils;
 
 import io.dropwizard.jdbi.args.ZonedDateTimeMapper;
-import org.joda.time.DateTime;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.StringMapper;
+import uk.gov.pay.publicauth.model.TokenHash;
+import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenPaymentType;
 
 import java.time.ZoneOffset;
@@ -22,22 +23,22 @@ public class DatabaseTestHelper {
         this.jdbi = jdbi;
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, String createdBy) {
+    public void insertAccount(TokenHash tokenHash, TokenLink randomTokenLink, String accountId, String description, String createdBy) {
         insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy) {
+    public void insertAccount(TokenHash tokenHash, TokenLink randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy) {
         insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed) {
+    public void insertAccount(TokenHash tokenHash, TokenLink randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed) {
         insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, lastUsed, CARD);
     }
 
-    public void insertAccount(String tokenHash, String randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed, TokenPaymentType tokenPaymentType) {
+    public void insertAccount(TokenHash tokenHash, TokenLink randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed, TokenPaymentType tokenPaymentType) {
         jdbi.withHandle(handle ->
         handle.insert("INSERT INTO tokens(token_hash, token_link, account_id, description, token_type, revoked, created_by, last_used) VALUES (?,?,?,?,?,(? at time zone 'utc'),?,(? at time zone 'utc'))",
-                tokenHash, randomTokenLink, accountId, description, tokenPaymentType,
+                tokenHash.getValue(), randomTokenLink.getValue(), accountId, description, tokenPaymentType,
                 revoked, createdBy, lastUsed));
     }
 
@@ -54,12 +55,12 @@ public class DatabaseTestHelper {
 
     }
 
-    public Map<String, Object> getTokenByHash(String tokenHash) {
+    public Map<String, Object> getTokenByHash(TokenHash tokenHash) {
         Map<String, Object> ret = jdbi.withHandle(h ->
                 h.createQuery("SELECT token_id, token_type, token_hash, account_id, issued, revoked, token_link, description, created_by " +
                         "FROM tokens t " +
                         "WHERE token_hash = :token_hash")
-                        .bind("token_hash", tokenHash)
+                        .bind("token_hash", tokenHash.getValue())
                         .first());
         return ret;
     }


### PR DESCRIPTION
## WHAT
 - We need to be able to revoke a token by hashed token itself rather
   than token_link, this is because we are passing the hashed token between
   products and the rest of the world
 - also introduced models `TokenHash` and `TokenLink` to type strings

