### PR TITLE
BAU Reduce logback log level

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <logger name="org.apache.http" level="info"
+            additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+</configuration>


### PR DESCRIPTION
We need to lower the logging level coming from the Apache HttpClient library because Apache httpclient by default logs everything at DEBUG level which is currently logging things that it shouldn't be logging.

Unfortunately adding the extra logging config to the yaml file used by Dropwizard does not work. It actually requires a logback.xml file.