### PR TITLE
BAU: Specify UTF-8 as the encoding of source code files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <artifactId>pay-publicauth</artifactId>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.7</dropwizard.version>
         <jackson.version>2.9.7</jackson.version>
         <guava.version>27.0.1-jre</guava.version>


### PR DESCRIPTION
This removes the following warning from the build:

`[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!`