### PR TITLE
PP-4573: Upgrade failsafe maven plugin to 3.0.0-M3

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-mvn -DskipTests clean package && docker build -t govukpay/publicauth:local .
+
+set -e
+
+mvn -DskipITs -DskipTests clean package
+docker build -t govukpay/publicauth:local .

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <includes>
                         <include>**/*ITest.java</include>


### PR DESCRIPTION
Even though this is a milestone release, if it passes CI I don't see why we shouldn't use it?
