### PR TITLE
PP-4584: Manage HTTP proxies via env. vars

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -4,10 +4,14 @@ set -eu
 RUN_MIGRATION=${RUN_MIGRATION:-false}
 RUN_APP=${RUN_APP:-true}
 
-java -jar *-allinone.jar waitOnDependencies *.yaml
+[ -z "${http_proxy:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttp.proxyHost=${http_proxy}"
+[ -z "${https_proxy:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttps.proxyHost=${https_proxy}"
+[ -z "${java_http_non_proxy_hosts:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttp.nonProxyHosts=${java_http_non_proxy_hosts}"
+
+java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then
-  java -jar *-allinone.jar db migrate *.yaml
+  java $JAVA_OPTS -jar *-allinone.jar db migrate *.yaml
 fi
 
 if [ "$RUN_APP" == "true" ]; then


### PR DESCRIPTION
Use environment variables to set JVM system properties for proxy configuration.

This makes the application respond to the following 3 environment variables:

http_proxy - passed as http.proxyHost
https_proxy - passed as https.proxyHost
java_http_non_proxy_hosts - passed as http.nonProxyHosts