### PR TITLE
BAU: Remove commons-collections4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,12 +140,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>testing</artifactId>
             <version>1.0.0-f6097986677849386f283bb84072198b57931b1b</version>

--- a/src/test/java/uk/gov/pay/publicauth/service/RandomIdGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/service/RandomIdGeneratorTest.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.google.common.primitives.Chars.asList;
-import static org.apache.commons.collections4.CollectionUtils.containsAll;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -33,10 +32,10 @@ public class RandomIdGeneratorTest {
         assertThat(randomIds.size(), is(numbersOfIdsToGenerate));
 
         // then 2. expects dictionary in Base32Hex
-        randomIds.stream().forEach(id -> {
-            assertThat(containsAll(BASE32_DICTIONARY, asList(id.toCharArray())), is(true));
+        for (String id : randomIds) {
+            assertThat(BASE32_DICTIONARY.containsAll(asList(id.toCharArray())), is(true));
             assertThat(id.length(), greaterThanOrEqualTo(RANDOM_ID_MIN_LENGTH));
             assertThat(id.length(), lessThanOrEqualTo(RANDOM_ID_MAX_LENGTH));
-        });
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.primitives.Chars.asList;
-import static org.apache.commons.collections4.CollectionUtils.containsAll;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
@@ -65,7 +64,7 @@ public class TokenServiceTest {
         // Minimum length guarantee is 32 for Hmac and an extremely very unlikely
         // minimum value of 1 length for the random Token this value is more likely to be 24~26 chars length
         assertThat(apiKey.length(), is(greaterThan(33)));
-        assertThat(containsAll(BASE32_HEX_DICTIONARY, asList(apiKey.toCharArray())), is(true));
+        assertThat(BASE32_HEX_DICTIONARY.containsAll(asList(apiKey.toCharArray())), is(true));
     }
 
     @Test


### PR DESCRIPTION
We only used this library for the 'containsAll' method in a couple of tests. We
can do this with the plain old collections API instead.


