### PR TITLE
BAU: Mark logback as a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
It's only used in our tests.