### PR TITLE
BAU: Mark dropwizard-testing as a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
## WHAT
This makes the .jar quite a lot smaller

