### PR TITLE
BAU: Clean up logging

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/filters/LoggingFilter.java
+++ b/src/main/java/uk/gov/pay/publicauth/filters/LoggingFilter.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.publicauth.filters;
 
 import com.google.common.base.Stopwatch;
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,11 +13,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.String.format;
-
 public class LoggingFilter implements Filter {
 
-    static final String HEADER_REQUEST_ID = "X-Request-Id";
     private static final Logger logger = LoggerFactory.getLogger(LoggingFilter.class);
 
     @Override
@@ -27,22 +23,24 @@ public class LoggingFilter implements Filter {
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) {
         Stopwatch stopwatch = Stopwatch.createStarted();
+        HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
 
-        String requestURL = ((HttpServletRequest) servletRequest).getRequestURI();
-        String requestMethod = ((HttpServletRequest) servletRequest).getMethod();
-        String requestId = StringUtils.defaultString(((HttpServletRequest) servletRequest).getHeader(HEADER_REQUEST_ID));
+        String requestURL = httpRequest.getRequestURI();
+        String requestMethod = httpRequest.getMethod();
+        String requestIdHeader = httpRequest.getHeader("X-Request-Id");
 
-        MDC.put(HEADER_REQUEST_ID, requestId);
+        // The key passed to MDC here should match the value in our logging configuration
+        MDC.put("X-Request-Id", requestIdHeader == null ? "(null)" : requestIdHeader);
 
-        logger.info(format("[%s] - %s to %s began", requestId, requestMethod, requestURL));
+        logger.info("{} to {} began", requestMethod, requestURL);
         try {
             filterChain.doFilter(servletRequest, servletResponse);
         } catch (Throwable throwable) {
-            logger.error("Exception - publicauth request - " + requestURL + " - exception - " + throwable.getMessage(), throwable);
+            logger.error("Exception - {}", throwable.getMessage(), throwable);
         } finally {
-            logger.info(format("[%s] - %s to %s ended - total time %dms", requestId, requestMethod, requestURL,
-                    stopwatch.elapsed(TimeUnit.MILLISECONDS)));
             stopwatch.stop();
+            logger.info("{} to {} ended - total time {}ms", requestMethod, requestURL,
+                    stopwatch.elapsed(TimeUnit.MILLISECONDS));
         }
     }
 

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
@@ -28,7 +28,7 @@ public class ApplicationStartupDependentResourceChecker {
         long timeToWait = 0;
         while(!databaseAvailable) {
             timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;
-            logger.info("Waiting for "+ timeToWait +" seconds till the database is available ...");
+            logger.info("Waiting for {} seconds till the database is available ...", timeToWait);
             applicationStartupDependentResource.sleep(timeToWait * 1000);
             databaseAvailable = isDatabaseAvailable();
         }

--- a/src/main/java/uk/gov/pay/publicauth/util/TrustStoreLoader.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/TrustStoreLoader.java
@@ -38,7 +38,9 @@ public class TrustStoreLoader {
             throw new RuntimeException("Could not create a keystore", e);
         }
 
-        if (CERTS_PATH != null) {
+        if (CERTS_PATH == null) {
+            logger.warn("CERTS_PATH environment variable not set - not loading any certificates");
+        } else {
             try {
                 Files.walk(Paths.get(CERTS_PATH)).forEach(certPath -> {
                     if (Files.isRegularFile(certPath)) {
@@ -46,16 +48,16 @@ public class TrustStoreLoader {
                             CertificateFactory cf = CertificateFactory.getInstance("X.509");
                             Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
                             TRUST_STORE.setCertificateEntry(certPath.getFileName().toString(), cert);
-                            logger.info("Loaded cert " + certPath);
+                            logger.info("Loaded cert {}", certPath);
                         } catch (SecurityException | KeyStoreException | CertificateException | IOException e) {
-                            logger.error("Could not load " + certPath, e);
+                            logger.error("Could not load {}", certPath, e);
                         }
                     }
                 });
             } catch (NoSuchFileException nsfe) {
-                logger.warn("Did not find any certificates to load");
+                logger.warn("Did not find any certificates to load in {}", CERTS_PATH);
             } catch (IOException ioe) {
-                logger.error("Error walking certs directory", ioe);
+                logger.error("Error walking certs directory {}", CERTS_PATH, ioe);
             }
         }
 

--- a/src/test/java/uk/gov/pay/publicauth/filters/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/filters/LoggingFilterTest.java
@@ -5,8 +5,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,19 +19,17 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.publicauth.filters.LoggingFilter.HEADER_REQUEST_ID;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LoggingFilterTest {
@@ -64,24 +60,21 @@ public class LoggingFilterTest {
 
     @Test
     public void shouldLogEntryAndExitPointsOfEndPoints() throws Exception {
-        String requestId = UUID.randomUUID().toString();
         String requestUrl = "/publicauth-request";
         String requestMethod = "GET";
 
         when(mockRequest.getRequestURI()).thenReturn(requestUrl);
         when(mockRequest.getMethod()).thenReturn(requestMethod);
-        when(mockRequest.getHeader(HEADER_REQUEST_ID)).thenReturn(requestId);
 
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl)));
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("%s to %s began", requestMethod, requestUrl)));
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
-        String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
-        assertTrue(NumberUtils.isCreatable(timeTaken[0]));
+        assertThat(endLogMessage, containsString(format("%s to %s ended - total time ", requestMethod, requestUrl)));
+        assertThat(endLogMessage, matchesRegex(".*total time \\d+ms"));
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
     }
 
@@ -99,9 +92,9 @@ public class LoggingFilterTest {
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", "", requestMethod, requestUrl)));
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("%s to %s began", requestMethod, requestUrl)));
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", "", requestMethod, requestUrl)));
+        assertThat(endLogMessage, containsString(format("%s to %s ended - total time ", requestMethod, requestUrl)));
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
     }
 
@@ -109,11 +102,9 @@ public class LoggingFilterTest {
     public void shouldLogEntryAndExitPointsEvenWhenFilterChainingThrowsException() throws Exception {
         String requestUrl = "/publicauth-url-with-exception";
         String requestMethod = "GET";
-        String requestId = UUID.randomUUID().toString();
 
         when(mockRequest.getRequestURI()).thenReturn(requestUrl);
         when(mockRequest.getMethod()).thenReturn(requestMethod);
-        when(mockRequest.getHeader(HEADER_REQUEST_ID)).thenReturn(requestId);
 
         IOException exception = new IOException("Failed request");
         doThrow(exception).when(mockFilterChain).doFilter(mockRequest, mockResponse);
@@ -123,14 +114,13 @@ public class LoggingFilterTest {
         verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl)));
-        assertThat(loggingEvents.get(1).getFormattedMessage(), is("Exception - publicauth request - " + requestUrl + " - exception - " + exception.getMessage()));
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("%s to %s began", requestMethod, requestUrl)));
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is(format("Exception - %s", exception.getMessage())));
         assertThat(loggingEvents.get(1).getLevel(), is(Level.ERROR));
         assertThat(loggingEvents.get(1).getThrowableProxy().getMessage(), is("Failed request"));
         String endLogMessage = loggingEvents.get(2).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
-        String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
-        assertTrue(NumberUtils.isCreatable(timeTaken[0]));
+        assertThat(endLogMessage, containsString(format("%s to %s ended - total time ", requestMethod, requestUrl)));
+        assertThat(endLogMessage, matchesRegex(".*total time \\d+ms"));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
* Stop doing string concatenation
* Include relevant information in errors from TrustStoreLoader
* Stop logging the request ID in our messages - it's done via MDC and our
  logFormat

