### PR TITLE
Declare the dropwizard-testing dependency a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
This should only be needed for running tests. Remove it from the runtime .jar

