### PR TITLE
Re-add httpclient, refactor TrustStoreLoader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,13 @@
             <version>0.4</version>
         </dependency>
         <dependency>
+            <!-- this has been added so we can use org.apache.http.conn.ssl.DefaultHostnameVerifier for Postgres.
+                it does not work with dropwizard 0.8.x but publicauth doesn't perform any outgoing HTTP calls -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.6</version>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.11</version>


### PR DESCRIPTION
## WHAT
* Reintroduce the `httpclient` dependency - `publicauth` was failing to start after removing it. No, I don't understand either.
* Reintroduce commit 29bd41fad5b4481a6eaf2c942ab5cda6a3adeee1 - it looks like this was not the source of our problems

## HOW 
_Steps to test or reproduce:_


