### PR TITLE
PP-4616: Refactor code to poll  for database availability on startup

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResource.java
@@ -22,11 +22,4 @@ public class ApplicationStartupDependentResource {
                 configuration.getDataSourceFactory().getPassword());
     }
 
-    public void sleep(long durationMilliseconds) {
-        try {
-            Thread.sleep(durationMilliseconds);
-        } catch (InterruptedException ignored) {
-        }
-    }
-
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResource.java
@@ -1,5 +1,5 @@
 package uk.gov.pay.publicauth.util;
 
-public interface ApplicationStartupDependentResource {
+interface ApplicationStartupDependentResource {
     boolean isAvailable();
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResource.java
@@ -1,25 +1,5 @@
 package uk.gov.pay.publicauth.util;
 
-
-import uk.gov.pay.publicauth.app.config.PublicAuthConfiguration;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-
-public class ApplicationStartupDependentResource {
-
-    private final PublicAuthConfiguration configuration;
-
-    ApplicationStartupDependentResource(PublicAuthConfiguration configuration) {
-        this.configuration = configuration;
-    }
-
-    public Connection getDatabaseConnection() throws SQLException {
-        return DriverManager.getConnection(
-                configuration.getDataSourceFactory().getUrl(),
-                configuration.getDataSourceFactory().getUser(),
-                configuration.getDataSourceFactory().getPassword());
-    }
-
+public interface ApplicationStartupDependentResource {
+    boolean isAvailable();
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
@@ -21,8 +21,6 @@ public class ApplicationStartupDependentResourceChecker {
     }
 
     private void waitingForDatabaseConnectivity() {
-        logger.info("Checking for database availability >>>");
-
         long timeToWait = 0;
         while(!isDatabaseAvailable()) {
             timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;
@@ -38,6 +36,7 @@ public class ApplicationStartupDependentResourceChecker {
             applicationStartupDependentResource.getDatabaseConnection().close();
             return true;
         } catch (SQLException e) {
+            logger.warn("Unable to connect to database: {}", e.getMessage());
             return false;
         }
     }

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
@@ -23,10 +23,10 @@ public class ApplicationStartupDependentResourceChecker {
         long timeToWait = 0;
         while(!applicationStartupDependentResource.isAvailable()) {
             timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;
-            logger.info("Waiting for {} seconds till the database is available ...", timeToWait);
+            logger.info("Waiting for {} seconds until {} is available ...", timeToWait, applicationStartupDependentResource);
             waiter.accept(Duration.ofSeconds(timeToWait));
         }
-        logger.info("Database available.");
+        logger.info("{} available.", applicationStartupDependentResource);
     }
 
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
@@ -5,15 +5,20 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 
+import java.time.Duration;
+import java.util.function.Consumer;
+
 public class ApplicationStartupDependentResourceChecker {
 
     private static final int PROGRESSIVE_SECONDS_TO_WAIT = 5;
     private static final Logger logger = LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class);
 
     private final ApplicationStartupDependentResource applicationStartupDependentResource;
+    private final Consumer<Duration> waiter;
 
-    public ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource) {
+    public ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource, Consumer<Duration> waiter) {
         this.applicationStartupDependentResource = applicationStartupDependentResource;
+        this.waiter = waiter;
     }
 
     public void checkAndWaitForResources() {
@@ -25,7 +30,7 @@ public class ApplicationStartupDependentResourceChecker {
         while(!isDatabaseAvailable()) {
             timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;
             logger.info("Waiting for {} seconds till the database is available ...", timeToWait);
-            applicationStartupDependentResource.sleep(timeToWait * 1000);
+            waiter.accept(Duration.ofSeconds(timeToWait));
         }
         logger.info("Database available.");
     }

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.function.Consumer;
 
-public class ApplicationStartupDependentResourceChecker {
+class ApplicationStartupDependentResourceChecker {
 
     private static final int PROGRESSIVE_SECONDS_TO_WAIT = 5;
     private static final Logger logger = LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class);
@@ -14,12 +14,12 @@ public class ApplicationStartupDependentResourceChecker {
     private final ApplicationStartupDependentResource applicationStartupDependentResource;
     private final Consumer<Duration> waiter;
 
-    public ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource, Consumer<Duration> waiter) {
+    ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource, Consumer<Duration> waiter) {
         this.applicationStartupDependentResource = applicationStartupDependentResource;
         this.waiter = waiter;
     }
 
-    public void checkAndWaitForResource() {
+    void checkAndWaitForResource() {
         long timeToWait = 0;
         while(!applicationStartupDependentResource.isAvailable()) {
             timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;

--- a/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/ApplicationStartupDependentResourceChecker.java
@@ -3,8 +3,6 @@ package uk.gov.pay.publicauth.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.SQLException;
-
 import java.time.Duration;
 import java.util.function.Consumer;
 
@@ -21,13 +19,9 @@ public class ApplicationStartupDependentResourceChecker {
         this.waiter = waiter;
     }
 
-    public void checkAndWaitForResources() {
-        waitingForDatabaseConnectivity();
-    }
-
-    private void waitingForDatabaseConnectivity() {
+    public void checkAndWaitForResource() {
         long timeToWait = 0;
-        while(!isDatabaseAvailable()) {
+        while(!applicationStartupDependentResource.isAvailable()) {
             timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;
             logger.info("Waiting for {} seconds till the database is available ...", timeToWait);
             waiter.accept(Duration.ofSeconds(timeToWait));
@@ -35,14 +29,4 @@ public class ApplicationStartupDependentResourceChecker {
         logger.info("Database available.");
     }
 
-
-    private boolean isDatabaseAvailable() {
-        try {
-            applicationStartupDependentResource.getDatabaseConnection().close();
-            return true;
-        } catch (SQLException e) {
-            logger.warn("Unable to connect to database: {}", e.getMessage());
-            return false;
-        }
-    }
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/DatabaseStartupResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DatabaseStartupResource.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.publicauth.util;
 
 
+import io.dropwizard.db.DataSourceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.publicauth.app.config.PublicAuthConfiguration;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -18,10 +18,10 @@ public class DatabaseStartupResource implements ApplicationStartupDependentResou
     private final String databaseUser;
     private final String databasePassword;
 
-    DatabaseStartupResource(PublicAuthConfiguration configuration) {
-        databaseUrl = configuration.getDataSourceFactory().getUrl();
-        databaseUser = configuration.getDataSourceFactory().getUser();
-        databasePassword = configuration.getDataSourceFactory().getPassword();
+    DatabaseStartupResource(DataSourceFactory dataSourceFactory) {
+        databaseUrl = dataSourceFactory.getUrl();
+        databaseUser = dataSourceFactory.getUser();
+        databasePassword = dataSourceFactory.getPassword();
     }
 
     public boolean isAvailable() {

--- a/src/main/java/uk/gov/pay/publicauth/util/DatabaseStartupResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DatabaseStartupResource.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.publicauth.util;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.publicauth.app.config.PublicAuthConfiguration;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class DatabaseStartupResource implements ApplicationStartupDependentResource {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseStartupResource.class);
+
+    private final PublicAuthConfiguration configuration;
+
+    DatabaseStartupResource(PublicAuthConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    public boolean isAvailable() {
+        try {
+            DriverManager.getConnection(
+                    configuration.getDataSourceFactory().getUrl(),
+                    configuration.getDataSourceFactory().getUser(),
+                    configuration.getDataSourceFactory().getPassword()).close();
+            return true;
+        } catch (SQLException e) {
+            logger.warn("Unable to connect to database: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/util/DatabaseStartupResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DatabaseStartupResource.java
@@ -8,26 +8,34 @@ import uk.gov.pay.publicauth.app.config.PublicAuthConfiguration;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import static java.lang.String.format;
+
 public class DatabaseStartupResource implements ApplicationStartupDependentResource {
 
     private static final Logger logger = LoggerFactory.getLogger(DatabaseStartupResource.class);
 
-    private final PublicAuthConfiguration configuration;
+    private final String databaseUrl;
+    private final String databaseUser;
+    private final String databasePassword;
 
     DatabaseStartupResource(PublicAuthConfiguration configuration) {
-        this.configuration = configuration;
+        databaseUrl = configuration.getDataSourceFactory().getUrl();
+        databaseUser = configuration.getDataSourceFactory().getUser();
+        databasePassword = configuration.getDataSourceFactory().getPassword();
     }
 
     public boolean isAvailable() {
         try {
-            DriverManager.getConnection(
-                    configuration.getDataSourceFactory().getUrl(),
-                    configuration.getDataSourceFactory().getUser(),
-                    configuration.getDataSourceFactory().getPassword()).close();
+            DriverManager.getConnection(databaseUrl, databaseUser, databasePassword).close();
             return true;
         } catch (SQLException e) {
             logger.warn("Unable to connect to database: {}", e.getMessage());
             return false;
         }
+    }
+
+    @Override
+    public String toString() {
+        return format("DatabaseStartupResource[url=%s, user=%s]", databaseUrl, databaseUser);
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
@@ -19,6 +19,6 @@ public class DependentResourceWaitCommand extends ConfiguredCommand<PublicAuthCo
             } catch (InterruptedException ignored) {
             }
         })
-                .checkAndWaitForResources();
+                .checkAndWaitForResource();
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
@@ -13,7 +13,12 @@ public class DependentResourceWaitCommand extends ConfiguredCommand<PublicAuthCo
 
     @Override
     protected void run(Bootstrap<PublicAuthConfiguration> bs, Namespace ns, PublicAuthConfiguration conf) {
-        ApplicationStartupDependentResourceChecker applicationStartupDependentResourceChecker = new ApplicationStartupDependentResourceChecker(new ApplicationStartupDependentResource(conf));
-        applicationStartupDependentResourceChecker.checkAndWaitForResources();
+        new ApplicationStartupDependentResourceChecker(new ApplicationStartupDependentResource(conf), duration -> {
+            try {
+                Thread.sleep(duration.getNano() / 1000);
+            } catch (InterruptedException ignored) {
+            }
+        })
+                .checkAndWaitForResources();
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
@@ -13,7 +13,7 @@ public class DependentResourceWaitCommand extends ConfiguredCommand<PublicAuthCo
 
     @Override
     protected void run(Bootstrap<PublicAuthConfiguration> bs, Namespace ns, PublicAuthConfiguration conf) {
-        new ApplicationStartupDependentResourceChecker(new ApplicationStartupDependentResource(conf), duration -> {
+        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf), duration -> {
             try {
                 Thread.sleep(duration.getNano() / 1000);
             } catch (InterruptedException ignored) {

--- a/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
@@ -13,7 +13,7 @@ public class DependentResourceWaitCommand extends ConfiguredCommand<PublicAuthCo
 
     @Override
     protected void run(Bootstrap<PublicAuthConfiguration> bs, Namespace ns, PublicAuthConfiguration conf) {
-        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf), duration -> {
+        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf.getDataSourceFactory()), duration -> {
             try {
                 Thread.sleep(duration.getNano() / 1000);
             } catch (InterruptedException ignored) {

--- a/src/test/java/uk/gov/pay/publicauth/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.publicauth.utils;
+package uk.gov.pay.publicauth.util;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -12,8 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.publicauth.util.DatabaseStartupResource;
-import uk.gov.pay.publicauth.util.ApplicationStartupDependentResourceChecker;
 
 import java.time.Duration;
 import java.util.List;

--- a/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.publicauth.utils;
 
 import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import org.junit.Before;
@@ -38,16 +37,15 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     @Mock
     Consumer<Duration> mockWaiter;
 
-    private Appender<ILoggingEvent> mockAppender;
+    private Appender mockAppender;
 
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
     @Before
     public void setup() {
-        Logger root = (Logger) LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class);
-        mockAppender = mockAppender();
-        root.addAppender(mockAppender);
+        mockAppender = mock(Appender.class);
+        ((Logger) LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class)).addAppender(mockAppender);
     }
 
     @Test
@@ -92,10 +90,5 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
         assertThat(logStatement.get(1).getFormattedMessage(), is("Waiting for 10 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
         assertThat(logStatement.get(2).getFormattedMessage(), is("Waiting for 15 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
         assertThat(logStatement.get(3).getFormattedMessage(), is("DatabaseStartupResource[url=mock, user=mock] available."));
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> Appender<T> mockAppender() {
-        return mock(Appender.class);
     }
 }

--- a/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -64,7 +64,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
         verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> allValues = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(allValues.get(0).getFormattedMessage(), is("Checking for database availability >>>"));
+        assertThat(allValues.get(0).getFormattedMessage(), is("Unable to connect to database: not there yet"));
         assertThat(allValues.get(1).getFormattedMessage(), is("Waiting for 5 seconds till the database is available ..."));
         assertThat(allValues.get(2).getFormattedMessage(), is("Database available."));
     }
@@ -84,14 +84,16 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
         verify(mockApplicationStartupDependentResource).sleep(5000L);
         verify(mockApplicationStartupDependentResource).sleep(10000L);
         verify(mockApplicationStartupDependentResource).sleep(15000L);
-        verify(mockAppender, times(5)).doAppend(loggingEventArgumentCaptor.capture());
+        verify(mockAppender, times(7)).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        assertThat(logStatement.get(0).getFormattedMessage(), is("Checking for database availability >>>"));
+        assertThat(logStatement.get(0).getFormattedMessage(), is("Unable to connect to database: not there"));
         assertThat(logStatement.get(1).getFormattedMessage(), is("Waiting for 5 seconds till the database is available ..."));
-        assertThat(logStatement.get(2).getFormattedMessage(), is("Waiting for 10 seconds till the database is available ..."));
-        assertThat(logStatement.get(3).getFormattedMessage(), is("Waiting for 15 seconds till the database is available ..."));
-        assertThat(logStatement.get(4).getFormattedMessage(), is("Database available."));
+        assertThat(logStatement.get(2).getFormattedMessage(), is("Unable to connect to database: not there yet"));
+        assertThat(logStatement.get(3).getFormattedMessage(), is("Waiting for 10 seconds till the database is available ..."));
+        assertThat(logStatement.get(4).getFormattedMessage(), is("Unable to connect to database: still not there"));
+        assertThat(logStatement.get(5).getFormattedMessage(), is("Waiting for 15 seconds till the database is available ..."));
+        assertThat(logStatement.get(6).getFormattedMessage(), is("Database available."));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -53,6 +53,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     @Test
     public void start_ShouldWaitAndLogUntilDatabaseIsAccessible() {
 
+        when(mockApplicationStartupDependentResource.toString()).thenReturn("DatabaseStartupResource[url=mock, user=mock]");
         when(mockApplicationStartupDependentResource.isAvailable())
                 .thenReturn(false)
                 .thenReturn(true);
@@ -65,12 +66,13 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> allValues = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(allValues.get(0).getFormattedMessage(), is("Waiting for 5 seconds till the database is available ..."));
-        assertThat(allValues.get(1).getFormattedMessage(), is("Database available."));
+        assertThat(allValues.get(0).getFormattedMessage(), is("Waiting for 5 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(allValues.get(1).getFormattedMessage(), is("DatabaseStartupResource[url=mock, user=mock] available."));
     }
 
     @Test
     public void start_ShouldProgressivelyIncrementSleepingTimeBetweenChecksForDBAccessibility() {
+        when(mockApplicationStartupDependentResource.toString()).thenReturn("DatabaseStartupResource[url=mock, user=mock]");
         when(mockApplicationStartupDependentResource.isAvailable())
                 .thenReturn(false)
                 .thenReturn(false)
@@ -86,10 +88,10 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
         verify(mockAppender, times(4)).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        assertThat(logStatement.get(0).getFormattedMessage(), is("Waiting for 5 seconds till the database is available ..."));
-        assertThat(logStatement.get(1).getFormattedMessage(), is("Waiting for 10 seconds till the database is available ..."));
-        assertThat(logStatement.get(2).getFormattedMessage(), is("Waiting for 15 seconds till the database is available ..."));
-        assertThat(logStatement.get(3).getFormattedMessage(), is("Database available."));
+        assertThat(logStatement.get(0).getFormattedMessage(), is("Waiting for 5 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(logStatement.get(1).getFormattedMessage(), is("Waiting for 10 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(logStatement.get(2).getFormattedMessage(), is("Waiting for 15 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(logStatement.get(3).getFormattedMessage(), is("DatabaseStartupResource[url=mock, user=mock] available."));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -18,7 +18,9 @@ import uk.gov.pay.publicauth.util.ApplicationStartupDependentResourceChecker;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -35,6 +37,8 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
 
     @Mock
     ApplicationStartupDependentResource mockApplicationStartupDependentResource;
+    @Mock
+    Consumer<Duration> mockWaiter;
 
     private Appender<ILoggingEvent> mockAppender;
 
@@ -59,7 +63,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
         applicationStartupDependentResourceChecker.checkAndWaitForResources();
 
         verify(mockApplicationStartupDependentResource, times(2)).getDatabaseConnection();
-        verify(mockApplicationStartupDependentResource).sleep(5000L);
+        verify(mockWaiter).accept(Duration.ofSeconds(5));
 
         verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> allValues = loggingEventArgumentCaptor.getAllValues();
@@ -81,9 +85,9 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
         applicationStartupDependentResourceChecker.checkAndWaitForResources();
 
         verify(mockApplicationStartupDependentResource, times(4)).getDatabaseConnection();
-        verify(mockApplicationStartupDependentResource).sleep(5000L);
-        verify(mockApplicationStartupDependentResource).sleep(10000L);
-        verify(mockApplicationStartupDependentResource).sleep(15000L);
+        verify(mockWaiter).accept(Duration.ofSeconds(5));
+        verify(mockWaiter).accept(Duration.ofSeconds(10));
+        verify(mockWaiter).accept(Duration.ofSeconds(15));
         verify(mockAppender, times(7)).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();


### PR DESCRIPTION
## WHAT
Clean up the abstractions in this code - there are layers in here, but they know too much about each other.

Separate out the thing being checked (`ApplicationStartupDependentResource`) and the thing doing the checking (`ApplicationStartupDependentResourceChecker`)

Make the database checker an implementation of `ApplicationStartupDependentResource` and remove application-specific knowledge from it so we can use the code in other microservices as-is.

Also separate out the waiting part of the checker so we can mock it in tests.

Finally, put the tests in the same package as the things they are testing so that more things can be package-private.

## HOW 
Our end to end tests will test this quite thoroughly.

