### PR TITLE
PP-4584: Pass JAVA_OPTS to all java invocations

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 
 set -eu
+
 RUN_MIGRATION=${RUN_MIGRATION:-false}
 RUN_APP=${RUN_APP:-true}
 
-java -jar *-allinone.jar waitOnDependencies *.yaml
+java ${JAVA_OPTS:-} -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then
-  java -jar *-allinone.jar db migrate *.yaml
+  java ${JAVA_OPTS:-} -jar *-allinone.jar db migrate *.yaml
 fi
 
 if [ "$RUN_APP" == "true" ]; then
-  java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+  java ${JAVA_OPTS:-} -jar *-allinone.jar server *.yaml
 fi
 
 exit 0


### PR DESCRIPTION
This will ensure proxy settings, memory limits etc. apply when waiting for the
database to come up as well as when applying database migrations.

Also, cope with JAVA_OPTS being unset.
