### PR TITLE
PP-4616: Use simpler ApplicationStartupDependentResourceChecker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <dropwizard.version>1.3.8</dropwizard.version>
         <jackson.version>2.9.8</jackson.version>
         <guava.version>27.0.1-jre</guava.version>
-        <pay-java-commons.version>1.0.20190117163809</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190118181040</pay-java-commons.version>
         <dependency-check.skip>true</dependency-check.skip>
     </properties>
     <repositories>

--- a/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/publicauth/util/DependentResourceWaitCommand.java
@@ -15,12 +15,7 @@ public class DependentResourceWaitCommand extends ConfiguredCommand<PublicAuthCo
 
     @Override
     protected void run(Bootstrap<PublicAuthConfiguration> bs, Namespace ns, PublicAuthConfiguration conf) {
-        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf.getDataSourceFactory()), duration -> {
-            try {
-                Thread.sleep(duration.getNano() / 1000);
-            } catch (InterruptedException ignored) {
-            }
-        })
+        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf.getDataSourceFactory()))
                 .checkAndWaitForResource();
     }
 }


### PR DESCRIPTION
Upgrade pay-java-commons to take advantage of an easier-to-use
implementation of ApplicationStartupDependentResourceChecker

