### PR TITLE
PP-5075: Document all environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,23 @@ API KEY validation algorithm:
 6. lookup `TOKEN_HASH` in database; return `true` iff found
 
 ## Environment variables
-| NAME                  | DESCRIPTION                                                                    |
-| ----------------------| ------------------------------------------------------------------------------ |
-| DB_SSL_OPTION         | To turn TLS on this value must be set as _“ssl=true”_. Otherwise must be empty. |
-| TOKEN_DB_BCRYPT_SALT  | Salt used for the hashing algorithm (bcrypt) to hash tokens before being stored in DB. |
-| TOKEN_API_HMAC_SECRET | HMAC secret to create the signature for the API Key. |
+| NAME                    | DESCRIPTION                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `ADMIN_PORT`            | The port number to listen for Dropwizard admin requests on. Defaults to `8081`. |
+| `CERTS_PATH`            | If set, add all certificates in this directory to the default Java truststore. |
+| `DB_HOST`               | The hostname of the database server. |
+| `DB_PASSWORD`           | The password for the `DB_USER` user. |
+| `DB_SSL_OPTION`         | To turn TLS on this value must be set as `ssl=true`. Otherwise must be empty. |
+| `DB_USER`               | The username to log into the database as. |
+| `JAVA_HOME`             | The location of the JRE. Set to `/opt/java/openjdk` in the `Dockerfile`. |
+| `JAVA_OPTS`             | Commandline arguments to pass to the java runtime. Optional. |
+| `METRICS_HOST`          | The hostname to send graphite metrics to. Defaults to `localhost`. |
+| `METRICS_PORT`          | The port number to send graphite metrics to. Defaults to `8092`. |
+| `PORT`                  | The port number to listen for requests on. Defaults to `8080`. |
+| `RUN_APP`               | Set to `true` to run the application. Defaults to `true`. |
+| `RUN_MIGRATION`         | Set to `true` to run a database migration. Defaults to `false`. |
+| `TOKEN_API_HMAC_SECRET` | HMAC secret to create the signature for the API Key. |
+| `TOKEN_DB_BCRYPT_SALT`  | Salt used for the hashing algorithm (bcrypt) to hash tokens before being stored in DB. |
 
 ## Integration tests
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -1,10 +1,10 @@
 server:
   applicationConnectors:
     - type: http
-      port: ${PORT}
+      port: ${PORT:-8080}
   adminConnectors:
     - type: http
-      port: ${ADMIN_PORT}
+      port: ${ADMIN_PORT:-8081}
 
 logging:
   level: INFO


### PR DESCRIPTION
This is the result of checking `docker-startup.sh` and the Dropwizard
configuration for all environment variables they use.

Also provide some sensible defaults for `PORT` and `ADMIN_PORT` in the
Dropwizard configuration, matching those set in the Dockerfile.
