### PR TITLE
PP-5160: µsvc agnostic db healthcheck

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
+++ b/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
@@ -82,7 +82,7 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
         environment.jersey().register(new HealthCheckResource(environment));
         environment.jersey().register(new ValidationExceptionMapper());
         environment.jersey().register(new TokenNotFoundExceptionMapper());
-        environment.healthChecks().register("database", new DatabaseHealthCheck(conf.getDataSourceFactory(), environment));
+        environment.healthChecks().register("database", new DatabaseHealthCheck(conf.getDataSourceFactory(), environment, "publicauth"));
 
         environment.servlets().addFilter("LoggingFilter", new LoggingFilter())
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1" + "/*");

--- a/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
+++ b/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
@@ -82,7 +82,7 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
         environment.jersey().register(new HealthCheckResource(environment));
         environment.jersey().register(new ValidationExceptionMapper());
         environment.jersey().register(new TokenNotFoundExceptionMapper());
-        environment.healthChecks().register("database", new DatabaseHealthCheck(conf,environment));
+        environment.healthChecks().register("database", new DatabaseHealthCheck(conf.getDataSourceFactory(), environment));
 
         environment.servlets().addFilter("LoggingFilter", new LoggingFilter())
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1" + "/*");

--- a/src/main/java/uk/gov/pay/publicauth/healthcheck/DatabaseHealthCheck.java
+++ b/src/main/java/uk/gov/pay/publicauth/healthcheck/DatabaseHealthCheck.java
@@ -3,8 +3,8 @@ package uk.gov.pay.publicauth.healthcheck;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
+import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
-import uk.gov.pay.publicauth.app.config.PublicAuthConfiguration;
 
 import javax.inject.Inject;
 import java.sql.Connection;
@@ -17,9 +17,10 @@ import java.util.Map;
 
 public class DatabaseHealthCheck extends HealthCheck {
 
-    private PublicAuthConfiguration configuration;
     private static final Map<String, Long> longDatabaseStatsMap;
     private static final Map<String, Double> doubleDatabaseStatsMap;
+
+    private final DataSourceFactory dataSourceFactory;
     private Integer statsHealthy = 0;
 
     static {
@@ -44,8 +45,8 @@ public class DatabaseHealthCheck extends HealthCheck {
     }
 
     @Inject
-    public DatabaseHealthCheck(PublicAuthConfiguration configuration, Environment environment) {
-        this.configuration = configuration;
+    public DatabaseHealthCheck(DataSourceFactory dataSourceFactory, Environment environment) {
+        this.dataSourceFactory = dataSourceFactory;
         initialiseMetrics(environment.metrics());
     }
 
@@ -62,9 +63,9 @@ public class DatabaseHealthCheck extends HealthCheck {
     @Override
     protected Result check() {
         try (Connection connection = DriverManager.getConnection(
-                configuration.getDataSourceFactory().getUrl(),
-                configuration.getDataSourceFactory().getUser(),
-                configuration.getDataSourceFactory().getPassword())) {
+                dataSourceFactory.getUrl(),
+                dataSourceFactory.getUser(),
+                dataSourceFactory.getPassword())) {
             connection.setReadOnly(true);
             updateMetricData(connection);
 


### PR DESCRIPTION
## WHAT
Remove hardcoded references to `publicauth` from the database healthcheck code

## HOW 
Do the tests still pass?
Is the code nice?

