### PR TITLE
Separate integration tests from unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
 
           sh 'docker pull govukpay/postgres:9.6.12'
           sh 'mvn -version'
-          sh 'mvn clean package'
+          sh 'mvn clean verify'
 
           postSuccessfulMetrics("publicauth.maven-build", stepBuildTime)
         }

--- a/build-local.sh
+++ b/build-local.sh
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")"
 
-mvn -DskipITs -DskipTests clean package
+mvn -DskipITs clean verify
 docker build -t govukpay/publicauth:local .

--- a/pom.xml
+++ b/pom.xml
@@ -273,19 +273,20 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M3</version>
-                <configuration>
-                    <includes>
-                        <include>**/*ITest.java</include>
-                    </includes>
-                </configuration>
                 <executions>
                     <execution>
                         <id>failsafe-integration-tests</id>
                         <phase>integration-test</phase>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
@@ -34,7 +34,7 @@ import static uk.gov.pay.publicauth.model.TokenSource.API;
 import static uk.gov.pay.publicauth.model.TokenSource.PRODUCTS;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
-public class AuthTokenDaoTest {
+public class AuthTokenDaoIT {
 
     private static final String TEST_USER_NAME = "test-user-name";
     private static final String TEST_USER_NAME_2 = "test-user-name-2";

--- a/src/test/java/uk/gov/pay/publicauth/it/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/HealthCheckResourceIT.java
@@ -10,7 +10,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HealthCheckResourceITest {
+public class HealthCheckResourceIT {
 
     @Rule
     public final DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
@@ -40,7 +40,7 @@ import static uk.gov.pay.publicauth.model.TokenSource.API;
 import static uk.gov.pay.publicauth.model.TokenSource.PRODUCTS;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
-public class PublicAuthResourceITest {
+public class PublicAuthResourceIT {
 
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd MMM YYYY - HH:mm");
 


### PR DESCRIPTION
Integration tests are slow. They involve starting a PostgreSQL container and
instantiating Dropwizard.

Split them from the unit tests and run the unit tests with the surefire plugin
instead.

Rename integration tests to match the default include/exclude rules for the
surefire and failsafe maven plugins. By default, the failsafe plugin will
include any tests matching IT*.java, *IT.java and *ITCase.java. This was not
the naming scheme our integration tests had, so fix that.

Since unit tests are so quick, we no longer need to skip them when running
local builds.

maven's 'package' target doesn't include running integration tests, so switch
to using the 'verify' target during CI builds, which is what we should've been
doing anyway.