### PR TITLE
REP-188: Calculate database metrics separately to healthchecks

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/healthcheck/DatabaseHealthCheck.java
+++ b/src/main/java/uk/gov/pay/publicauth/healthcheck/DatabaseHealthCheck.java
@@ -1,65 +1,21 @@
 package uk.gov.pay.publicauth.healthcheck;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
+import uk.gov.pay.publicauth.service.DatabaseMetricsService;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static java.lang.String.format;
 
 public class DatabaseHealthCheck extends HealthCheck {
 
-    private static final Map<String, Long> longDatabaseStatsMap;
-    private static final Map<String, Double> doubleDatabaseStatsMap;
-
-    private final String databaseName;
     private final DataSourceFactory dataSourceFactory;
-    private Integer statsHealthy = 0;
-
-    static {
-        longDatabaseStatsMap = new HashMap<>();
-        longDatabaseStatsMap.put("numbackends", 0L);
-        longDatabaseStatsMap.put("xact_commit", 0L);
-        longDatabaseStatsMap.put("xact_rollback", 0L);
-        longDatabaseStatsMap.put("blks_read", 0L);
-        longDatabaseStatsMap.put("blks_hit", 0L);
-        longDatabaseStatsMap.put("tup_returned", 0L);
-        longDatabaseStatsMap.put("tup_fetched", 0L);
-        longDatabaseStatsMap.put("tup_inserted", 0L);
-        longDatabaseStatsMap.put("tup_updated", 0L);
-        longDatabaseStatsMap.put("tup_deleted", 0L);
-        longDatabaseStatsMap.put("conflicts", 0L);
-        longDatabaseStatsMap.put("temp_files", 0L);
-        longDatabaseStatsMap.put("temp_bytes", 0L);
-        longDatabaseStatsMap.put("deadlocks", 0L);
-        doubleDatabaseStatsMap = new HashMap<>();
-        doubleDatabaseStatsMap.put("blk_read_time", 0.0);
-        doubleDatabaseStatsMap.put("blk_write_time", 0.0);
-    }
+    private final DatabaseMetricsService metricsService;
 
     public DatabaseHealthCheck(DataSourceFactory dataSourceFactory, Environment environment, String databaseName) {
         this.dataSourceFactory = dataSourceFactory;
-        initialiseMetrics(environment.metrics());
-        this.databaseName = databaseName;
-    }
-
-    private void initialiseMetrics(MetricRegistry metricRegistry) {
-        for (String key : longDatabaseStatsMap.keySet()) {
-            metricRegistry.<Gauge<Long>>register(format("%sdb.%s", databaseName, key), () -> longDatabaseStatsMap.get(key));
-        }
-        for (String key : doubleDatabaseStatsMap.keySet()) {
-            metricRegistry.<Gauge<Double>>register(format("%sdb.%s", databaseName, key), () -> doubleDatabaseStatsMap.get(key));
-        }
-        metricRegistry.<Gauge<Integer>>register(format("%sdb.stats_healthy", databaseName), () -> statsHealthy);
+        this.metricsService = new DatabaseMetricsService(dataSourceFactory, environment.metrics(), databaseName);
     }
 
     @Override
@@ -69,30 +25,11 @@ public class DatabaseHealthCheck extends HealthCheck {
                 dataSourceFactory.getUser(),
                 dataSourceFactory.getPassword())) {
             connection.setReadOnly(true);
-            updateMetricData(connection);
+            metricsService.updateMetricData();
 
             return connection.isValid(2) ? Result.healthy() : Result.unhealthy("Could not validate the DB connection.");
         } catch (Exception e) {
             return Result.unhealthy(e.getMessage());
-        }
-    }
-
-    private void updateMetricData(Connection connection) {
-        try (PreparedStatement statement = connection.prepareStatement("select * from pg_stat_database where datname = ?")) {
-            statement.setString(1, databaseName);
-            statement.execute();
-            try (ResultSet resultSet = statement.getResultSet()) {
-                resultSet.next();
-                for (String key : longDatabaseStatsMap.keySet()) {
-                    longDatabaseStatsMap.put(key, resultSet.getLong(key));
-                }
-                for (String key : doubleDatabaseStatsMap.keySet()) {
-                    doubleDatabaseStatsMap.put(key, resultSet.getDouble(key));
-                }
-            }
-            statsHealthy = 1;
-        } catch (SQLException e) {
-            statsHealthy = 0;
         }
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/healthcheck/DatabaseHealthCheck.java
+++ b/src/main/java/uk/gov/pay/publicauth/healthcheck/DatabaseHealthCheck.java
@@ -2,8 +2,6 @@ package uk.gov.pay.publicauth.healthcheck;
 
 import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.setup.Environment;
-import uk.gov.pay.publicauth.service.DatabaseMetricsService;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -11,11 +9,9 @@ import java.sql.DriverManager;
 public class DatabaseHealthCheck extends HealthCheck {
 
     private final DataSourceFactory dataSourceFactory;
-    private final DatabaseMetricsService metricsService;
 
-    public DatabaseHealthCheck(DataSourceFactory dataSourceFactory, Environment environment, String databaseName) {
+    public DatabaseHealthCheck(DataSourceFactory dataSourceFactory) {
         this.dataSourceFactory = dataSourceFactory;
-        this.metricsService = new DatabaseMetricsService(dataSourceFactory, environment.metrics(), databaseName);
     }
 
     @Override
@@ -25,7 +21,6 @@ public class DatabaseHealthCheck extends HealthCheck {
                 dataSourceFactory.getUser(),
                 dataSourceFactory.getPassword())) {
             connection.setReadOnly(true);
-            metricsService.updateMetricData();
 
             return connection.isValid(2) ? Result.healthy() : Result.unhealthy("Could not validate the DB connection.");
         } catch (Exception e) {

--- a/src/main/java/uk/gov/pay/publicauth/service/DatabaseMetricsService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/DatabaseMetricsService.java
@@ -9,85 +9,66 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Set;
 
 import static java.lang.String.format;
 
 public class DatabaseMetricsService {
 
-    private static final Map<String, Long> longDatabaseStatsMap;
-    private static final Map<String, Double> doubleDatabaseStatsMap;
+    private final Set<PostgresMetric> metrics = Set.of(
+            new LongPostgresMetric("numbackends", 0L),
+            new LongPostgresMetric("xact_commit", 0L),
+            new LongPostgresMetric("xact_rollback", 0L),
+            new LongPostgresMetric("blks_read", 0L),
+            new LongPostgresMetric("blks_hit", 0L),
+            new LongPostgresMetric("tup_returned", 0L),
+            new LongPostgresMetric("tup_fetched", 0L),
+            new LongPostgresMetric("tup_inserted", 0L),
+            new LongPostgresMetric("tup_updated", 0L),
+            new LongPostgresMetric("tup_deleted", 0L),
+            new LongPostgresMetric("conflicts", 0L),
+            new LongPostgresMetric("temp_files", 0L),
+            new LongPostgresMetric("temp_bytes", 0L),
+            new LongPostgresMetric("deadlocks", 0L),
+            new DoublePostgresMetric("blk_read_time", 0.0),
+            new DoublePostgresMetric("blk_write_time", 0.0));
 
     private final String databaseName;
     private final DataSourceFactory dataSourceFactory;
     private Integer statsHealthy = 0;
 
-    static {
-        longDatabaseStatsMap = new HashMap<>();
-        longDatabaseStatsMap.put("numbackends", 0L);
-        longDatabaseStatsMap.put("xact_commit", 0L);
-        longDatabaseStatsMap.put("xact_rollback", 0L);
-        longDatabaseStatsMap.put("blks_read", 0L);
-        longDatabaseStatsMap.put("blks_hit", 0L);
-        longDatabaseStatsMap.put("tup_returned", 0L);
-        longDatabaseStatsMap.put("tup_fetched", 0L);
-        longDatabaseStatsMap.put("tup_inserted", 0L);
-        longDatabaseStatsMap.put("tup_updated", 0L);
-        longDatabaseStatsMap.put("tup_deleted", 0L);
-        longDatabaseStatsMap.put("conflicts", 0L);
-        longDatabaseStatsMap.put("temp_files", 0L);
-        longDatabaseStatsMap.put("temp_bytes", 0L);
-        longDatabaseStatsMap.put("deadlocks", 0L);
-        doubleDatabaseStatsMap = new HashMap<>();
-        doubleDatabaseStatsMap.put("blk_read_time", 0.0);
-        doubleDatabaseStatsMap.put("blk_write_time", 0.0);
-    }
-
     public DatabaseMetricsService(DataSourceFactory dataSourceFactory, MetricRegistry metricRegistry, String databaseName) {
         this.dataSourceFactory = dataSourceFactory;
         this.databaseName = databaseName;
-        initialiseMetrics(metricRegistry);
-    }
-
-    private void initialiseMetrics(MetricRegistry metricRegistry) {
-        for (String key : longDatabaseStatsMap.keySet()) {
-            metricRegistry.<Gauge<Long>>register(format("%sdb.%s", databaseName, key), () -> longDatabaseStatsMap.get(key));
-        }
-        for (String key : doubleDatabaseStatsMap.keySet()) {
-            metricRegistry.<Gauge<Double>>register(format("%sdb.%s", databaseName, key), () -> doubleDatabaseStatsMap.get(key));
-        }
+        metrics.forEach(metric -> metric.register(metricRegistry, format("%sdb.", databaseName)));
         metricRegistry.<Gauge<Integer>>register(format("%sdb.stats_healthy", databaseName), () -> statsHealthy);
     }
 
     public void updateMetricData() {
+        statsHealthy = fetchDatabaseMetrics() ? 1 : 0;
+    }
+
+    private boolean fetchDatabaseMetrics() {
         try (Connection connection = DriverManager.getConnection(
                 dataSourceFactory.getUrl(),
                 dataSourceFactory.getUser(),
-                dataSourceFactory.getPassword())) {
+                dataSourceFactory.getPassword());
+             PreparedStatement statement = connection.prepareStatement("select * from pg_stat_database where datname = ?")) {
             connection.setReadOnly(true);
-            try (PreparedStatement statement = connection.prepareStatement("select * from pg_stat_database where datname = ?")) {
-                statement.setString(1, databaseName);
-                if (statement.execute()) {
-                    try (ResultSet resultSet = statement.getResultSet()) {
-                        if (resultSet.next()) {
-                            for (String key : longDatabaseStatsMap.keySet()) {
-                                longDatabaseStatsMap.put(key, resultSet.getLong(key));
-                            }
-                            for (String key : doubleDatabaseStatsMap.keySet()) {
-                                doubleDatabaseStatsMap.put(key, resultSet.getDouble(key));
-                            }
-                            statsHealthy = 1;
-                        } else {
-                            statsHealthy = 0;
+            statement.setString(1, databaseName);
+            if (statement.execute()) {
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    if (resultSet.next()) {
+                        for (PostgresMetric metric : metrics) {
+                            metric.setValueFromResultSet(resultSet);
                         }
+                        return true;
                     }
-                } else {
-                    statsHealthy = 0;
                 }
             }
-        } catch (SQLException e) {
-            statsHealthy = 0;
+        } catch (SQLException ignored) {
         }
+
+        return false;
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/service/DatabaseMetricsService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/DatabaseMetricsService.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.publicauth.service;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.db.DataSourceFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+public class DatabaseMetricsService {
+
+    private static final Map<String, Long> longDatabaseStatsMap;
+    private static final Map<String, Double> doubleDatabaseStatsMap;
+
+    private final String databaseName;
+    private final DataSourceFactory dataSourceFactory;
+    private Integer statsHealthy = 0;
+
+    static {
+        longDatabaseStatsMap = new HashMap<>();
+        longDatabaseStatsMap.put("numbackends", 0L);
+        longDatabaseStatsMap.put("xact_commit", 0L);
+        longDatabaseStatsMap.put("xact_rollback", 0L);
+        longDatabaseStatsMap.put("blks_read", 0L);
+        longDatabaseStatsMap.put("blks_hit", 0L);
+        longDatabaseStatsMap.put("tup_returned", 0L);
+        longDatabaseStatsMap.put("tup_fetched", 0L);
+        longDatabaseStatsMap.put("tup_inserted", 0L);
+        longDatabaseStatsMap.put("tup_updated", 0L);
+        longDatabaseStatsMap.put("tup_deleted", 0L);
+        longDatabaseStatsMap.put("conflicts", 0L);
+        longDatabaseStatsMap.put("temp_files", 0L);
+        longDatabaseStatsMap.put("temp_bytes", 0L);
+        longDatabaseStatsMap.put("deadlocks", 0L);
+        doubleDatabaseStatsMap = new HashMap<>();
+        doubleDatabaseStatsMap.put("blk_read_time", 0.0);
+        doubleDatabaseStatsMap.put("blk_write_time", 0.0);
+    }
+
+    public DatabaseMetricsService(DataSourceFactory dataSourceFactory, MetricRegistry metricRegistry, String databaseName) {
+        this.dataSourceFactory = dataSourceFactory;
+        this.databaseName = databaseName;
+        initialiseMetrics(metricRegistry);
+    }
+
+    private void initialiseMetrics(MetricRegistry metricRegistry) {
+        for (String key : longDatabaseStatsMap.keySet()) {
+            metricRegistry.<Gauge<Long>>register(format("%sdb.%s", databaseName, key), () -> longDatabaseStatsMap.get(key));
+        }
+        for (String key : doubleDatabaseStatsMap.keySet()) {
+            metricRegistry.<Gauge<Double>>register(format("%sdb.%s", databaseName, key), () -> doubleDatabaseStatsMap.get(key));
+        }
+        metricRegistry.<Gauge<Integer>>register(format("%sdb.stats_healthy", databaseName), () -> statsHealthy);
+    }
+
+    public void updateMetricData() {
+        try (Connection connection = DriverManager.getConnection(
+                    dataSourceFactory.getUrl(),
+                    dataSourceFactory.getUser(),
+                    dataSourceFactory.getPassword())) {
+            connection.setReadOnly(true);
+            try (PreparedStatement statement = connection.prepareStatement("select * from pg_stat_database where datname = ?")) {
+                statement.setString(1, databaseName);
+                statement.execute();
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    resultSet.next();
+                    for (String key : longDatabaseStatsMap.keySet()) {
+                        longDatabaseStatsMap.put(key, resultSet.getLong(key));
+                    }
+                    for (String key : doubleDatabaseStatsMap.keySet()) {
+                        doubleDatabaseStatsMap.put(key, resultSet.getDouble(key));
+                    }
+                }
+                statsHealthy = 1;
+            }
+        } catch (SQLException e) {
+            statsHealthy = 0;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/service/DoublePostgresMetric.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/DoublePostgresMetric.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.publicauth.service;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DoublePostgresMetric extends PostgresMetric<Double> {
+    DoublePostgresMetric(String name, Double value) {
+        super(name, value);
+    }
+
+    void setValueFromResultSet(ResultSet resultSet) throws SQLException {
+        value = resultSet.getDouble(getName());
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/service/LongPostgresMetric.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/LongPostgresMetric.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.publicauth.service;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class LongPostgresMetric extends PostgresMetric<Long> {
+    LongPostgresMetric(String name, Long value) {
+        super(name, value);
+    }
+
+    void setValueFromResultSet(ResultSet resultSet) throws SQLException {
+        value = resultSet.getLong(getName());
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/service/PostgresMetric.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/PostgresMetric.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.publicauth.service;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+abstract class PostgresMetric<T> implements Gauge<T> {
+    private final String name;
+    protected T value;
+
+    PostgresMetric(String name, T defaultValue) {
+        this.name = name;
+        this.value = defaultValue;
+    }
+
+    String getName() {
+        return name;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    void register(MetricRegistry registry, String prefix) {
+        registry.<Gauge<T>>register(String.format("%s%s", prefix, name), this);
+    }
+
+    abstract void setValueFromResultSet(ResultSet resultSet) throws SQLException;
+}


### PR DESCRIPTION
## WHAT
Move database metrics polling to a dedicated thread, rather than calculating them as a side-effect of the database healthcheck.

## HOW 
I tried testing this against a postgres container and it pulled metrics but they were all zeros (this might be fine)

If this is good, both the healthcheck code and the metrics code can move to `pay-java-commons`

## OPEN QUESTIONS
Do we need to create our own thread? Is there already one we can use somewhere?
Is the thread polling at a sensible rate? (currently it's twice the rate at which we report in to graphite)