### PR TITLE
Use runAppE2E to run end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ pipeline {
 
   parameters {
     booleanParam(defaultValue: false, description: '', name: 'runEndToEndTestsOnPR')
-    booleanParam(defaultValue: false, description: '', name: 'runZapTestsOnPR')
   }
 
   options {
@@ -20,7 +19,6 @@ pipeline {
   environment {
     DOCKER_HOST = "unix:///var/run/docker.sock"
     RUN_END_TO_END_ON_PR = "${params.runEndToEndTestsOnPR}"
-    RUN_ZAP_ON_PR = "${params.runZapTestsOnPR}"
     JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
   }
 
@@ -59,8 +57,8 @@ pipeline {
     }
     stage('Tests') {
       failFast true
-      parallel {
-        stage('Card Payment End-to-End Tests') {
+      stages {
+        stage('End-to-End Tests') {
             when {
                 anyOf {
                   branch 'master'
@@ -68,20 +66,9 @@ pipeline {
                 }
             }
             steps {
-                runCardPaymentsE2E("publicauth")
+                runAppE2E("publicauth", "card,zap")
             }
         }
-         stage('ZAP Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_ZAP_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runZap("publicauth")
-            }
-         }
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
Let's deprecate the run{test}E2E groovy routines and use runAppE2E everywhere
