### PR TITLE
PP-5722: The Gson library is needed by the json logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,12 +145,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>testing</artifactId>
             <version>${pay-java-commons.version}</version>


### PR DESCRIPTION
The Gson library is transitively pulled in via the uk.gov.pay:logging
dependency. However this was not actually pulled in because of a current Gson
dependency with the test scope. This caused the service to fail to start up
during the end to end test with

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.fasterxml.jackson.module.afterburner.util.MyClassLoader (file:/app/pay-publicauth-0.1-SNAPSHOT-allinone.jar) to method java.lang.ClassLoader.findLoadedClass(java.lang.String)
WARNING: Please consider reporting this to the maintainers of com.fasterxml.jackson.module.afterburner.util.MyClassLoader
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
java.lang.NoClassDefFoundError: com/google/gson/Gson
	at uk.gov.pay.logging.LogstashConsoleAppenderFactory.build(LogstashConsoleAppenderFactory.java:32)
	at io.dropwizard.logging.DefaultLoggingFactory.configure(DefaultLoggingFactory.java:143)
	at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:83)
	at io.dropwizard.cli.Cli.run(Cli.java:78)
	at io.dropwizard.Application.run(Application.java:93)
	at uk.gov.pay.publicauth.app.PublicAuthApp.main(PublicAuthApp.java:116)
Caused by: java.lang.ClassNotFoundException: com.google.gson.Gson
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	... 6 more
```

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


