### PR TITLE
PP-5725 Add Sentry config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
             <artifactId>utils</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dhatim</groupId>
+            <artifactId>dropwizard-sentry</artifactId>
+            <version>1.3.9-1</version>
+        </dependency>
+
         <!-- testing -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -14,6 +14,10 @@ logging:
       target: stdout
       customFields:
         container: "publicauth"
+    - type: sentry
+      threshold: ERROR
+      dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
+      environment: ${ENVIRONMENT}
 
 database:
   driverClass: org.postgresql.Driver


### PR DESCRIPTION
Add Sentry logging appender so that logs at ERROR level and uncaught
exceptions are reported to Sentry. Same implementations as per
alphagov/pay-direct-debit-connector#745

There is a default value for the dsn so that the app will start if the
SENTRY_DSN env variable has not been set.