### PR TITLE
Pp 6002 replace json node with request type

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -3,6 +3,7 @@ package uk.gov.pay.publicauth.dao;
 import org.jdbi.v3.core.Jdbi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.publicauth.model.CreateTokenRequest;
 import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenPaymentType;
@@ -69,21 +70,21 @@ public class AuthTokenDao {
         return rowsUpdated > 0;
     }
 
-    public void storeToken(TokenHash tokenHash, TokenLink randomTokenLink, TokenSource tokenSource, String accountId, String description, String createdBy, TokenPaymentType tokenPaymentType) {
+    public void storeToken(TokenHash tokenHash, CreateTokenRequest createTokenRequest) {
         Integer rowsUpdated = jdbi.withHandle(handle ->
                 handle.createUpdate("INSERT INTO tokens(token_hash, token_link, type, description, account_id, created_by, token_type) " +
                         "VALUES (:token_hash,:token_link,:type,:description,:account_id,:created_by,:token_type)")
                         .bind("token_hash", tokenHash.getValue())
-                        .bind("token_link", randomTokenLink.getValue())
-                        .bind("type", tokenSource)
-                        .bind("description", description)
-                        .bind("account_id", accountId)
-                        .bind("created_by", createdBy)
-                        .bind("token_type", tokenPaymentType)
+                        .bind("token_link", createTokenRequest.getTokenLink().getValue())
+                        .bind("type", createTokenRequest.getTokenSource())
+                        .bind("description", createTokenRequest.getDescription())
+                        .bind("account_id", createTokenRequest.getAccountId())
+                        .bind("created_by", createTokenRequest.getCreatedBy())
+                        .bind("token_type", createTokenRequest.getTokenPaymentType())
                         .execute());
         if (rowsUpdated != 1) {
-            LOGGER.error("Unable to store new token for account '{}'. '{}' rows were updated", accountId, rowsUpdated);
-            throw new RuntimeException(String.format("Unable to store new token for account %s}", accountId));
+            LOGGER.error("Unable to store new token for account '{}'. '{}' rows were updated", createTokenRequest.getAccountId(), rowsUpdated);
+            throw new RuntimeException(String.format("Unable to store new token for account %s}", createTokenRequest.getAccountId()));
         }
     }
 

--- a/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.publicauth.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+
+import static java.util.UUID.randomUUID;
+import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
+import static uk.gov.pay.publicauth.model.TokenSource.API;
+
+public class CreateTokenRequest {
+
+    @NotNull private final String accountId;
+    @NotNull private final String description;
+    @NotNull private final String createdBy;
+    private final TokenPaymentType tokenPaymentType;
+    private final TokenSource tokenSource;
+    private final TokenLink tokenLink = TokenLink.of(randomUUID().toString());
+
+    @JsonCreator
+    public CreateTokenRequest(@JsonProperty("account_id") String accountId,
+                              @JsonProperty("description") String description,
+                              @JsonProperty("created_by") String createdBy,
+                              @JsonProperty("token_type") TokenPaymentType tokenPaymentType,
+                              @JsonProperty("type") TokenSource tokenSource) {
+        this.accountId = accountId;
+        this.description = description;
+        this.createdBy = createdBy;
+        this.tokenPaymentType = tokenPaymentType == null ? CARD : tokenPaymentType;
+        this.tokenSource = tokenSource == null ? API : tokenSource;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public TokenPaymentType getTokenPaymentType() {
+        return tokenPaymentType;
+    }
+
+    public TokenSource getTokenSource() {
+        return tokenSource;
+    }
+
+    public TokenLink getTokenLink() {
+        return tokenLink;
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -88,13 +88,7 @@ public class PublicAuthResource {
     public Response createTokenForAccount(@NotNull @Valid CreateTokenRequest createTokenRequest) {
 
         Tokens token = tokenService.issueTokens();
-        authDao.storeToken(token.getHashedToken(),
-                createTokenRequest.getTokenLink(),
-                createTokenRequest.getTokenSource(),
-                createTokenRequest.getAccountId(),
-                createTokenRequest.getDescription(),
-                createTokenRequest.getCreatedBy(),
-                createTokenRequest.getTokenPaymentType());
+        authDao.storeToken(token.getHashedToken(), createTokenRequest);
         LOGGER.info("Created token with {}", createTokenRequest.getTokenLink());
         return ok(ImmutableMap.of("token", token.getApiKey())).build();
     }

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import uk.gov.pay.publicauth.model.CreateTokenRequest;
 import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
@@ -186,7 +187,8 @@ public class AuthTokenDaoIT {
 
     @Test
     public void shouldInsertNewToken() {
-        authTokenDao.storeToken(TokenHash.of("token-hash"), TokenLink.of("token-link"), API, "account-id", "description", "user", CARD);
+        var createTokenRequest = new CreateTokenRequest("account-id", "description", "user", CARD, API);
+        authTokenDao.storeToken(TokenHash.of("token-hash"), createTokenRequest);
         Map<String, Object> tokenByHash = app.getDatabaseHelper().getTokenByHash(TokenHash.of("token-hash"));
         ZonedDateTime now = app.getDatabaseHelper().getCurrentTime();
 
@@ -316,7 +318,8 @@ public class AuthTokenDaoIT {
     public void shouldErrorIfTriesToSaveTheSameTokenTwice() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
-        authTokenDao.storeToken(TOKEN_HASH, TOKEN_LINK, API, ACCOUNT_ID, TOKEN_DESCRIPTION, "test@email.com", CARD);
+        var createTokenRequest = new CreateTokenRequest(ACCOUNT_ID, TOKEN_DESCRIPTION, "test@email.com", CARD, API);
+        authTokenDao.storeToken(TOKEN_HASH, createTokenRequest);
     }
 
     private Matcher<ChronoZonedDateTime<?>> isCloseTo(ZonedDateTime now) {

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
@@ -27,6 +27,7 @@ import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -164,31 +165,35 @@ public class PublicAuthResourceIT {
     }
     
     @Test
-    public void respondWith400_ifAccountAndDescriptionAreMissing() {
+    public void respondWith422_ifAccountAndDescriptionAreMissing() {
         createTokenFor("{}")
-                .statusCode(400)
-                .body("message", is("Missing fields: [account_id, description, created_by]"));
+            .statusCode(422)
+            .body("errors.size()", is(3))
+            .body("errors", containsInAnyOrder(
+                "description must not be null",
+                "createdBy must not be null",
+                "accountId must not be null"));
     }
 
     @Test
-    public void respondWith400_ifAccountIsMissing() {
+    public void respondWith422_ifAccountIsMissing() {
         createTokenFor("{\"description\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\"}")
-                .statusCode(400)
-                .body("message", is("Missing fields: [account_id]"));
+            .statusCode(422)
+            .body("errors", equalTo(List.of("accountId must not be null")));
     }
 
     @Test
-    public void respondWith400_ifDescriptionIsMissing() {
+    public void respondWith422_ifDescriptionIsMissing() {
         createTokenFor("{\"account_id\" : \"" + ACCOUNT_ID + "\", \"created_by\": \"some-user\"}")
-                .statusCode(400)
-                .body("message", is("Missing fields: [description]"));
+            .statusCode(422)
+            .body("errors", equalTo(List.of("description must not be null")));
     }
 
     @Test
-    public void respondWith400_ifBodyIsMissing() {
+    public void respondWith422_ifBodyIsMissing() {
         createTokenFor("")
-                .statusCode(400)
-                .body("message", is("Body cannot be empty"));
+            .statusCode(422)
+            .body("errors", equalTo(List.of("The request body must not be null")));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
Commit 1: Change the `createTokenForAccount` endpoint to use a `CreateTokenRequest` type with validation rather than a `JsonNode` being validated within the method body. 
Commit 2: Modify `AuthTokenDao.storeToken` to take the `CreateTokenRequest` type to reduce the number of parameters being passed.


