### PR TITLE
PP-6001 Upgrade dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.3.17</dropwizard.version>
-        <jackson.version>2.9.10.1</jackson.version>
+        <dropwizard.version>2.0.0</dropwizard.version>
+        <jackson.version>2.10.0.pr3</jackson.version>
         <guava.version>28.2-jre</guava.version>
         <pay-java-commons.version>1.0.20200107160358</pay-java-commons.version>
     </properties>
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-jdbi</artifactId>
+            <artifactId>dropwizard-jdbi3</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>1.3.9-2</version>
+            <version>2.0.0-4</version>
         </dependency>
 
         <!-- testing -->

--- a/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
+++ b/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
@@ -10,12 +10,12 @@ import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.jdbi.DBIFactory;
-import io.dropwizard.jdbi.bundles.DBIExceptionsBundle;
+import io.dropwizard.jdbi3.JdbiFactory;
+import io.dropwizard.jdbi3.bundles.JdbiExceptionsBundle;
 import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.skife.jdbi.v2.DBI;
+import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.commons.utils.healthchecks.DatabaseHealthCheck;
 import uk.gov.pay.commons.utils.metrics.DatabaseMetricsService;
 import uk.gov.pay.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
@@ -44,7 +44,7 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
     private static final String SERVICE_METRICS_NODE = "publicauth";
     private static final int GRAPHITE_SENDING_PERIOD_SECONDS = 10;
 
-    private DBI jdbi;
+    private Jdbi jdbi;
 
     @Override
     public void initialize(Bootstrap<PublicAuthConfiguration> bootstrap) {
@@ -54,7 +54,7 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
                 )
         );
 
-        bootstrap.addBundle(new DBIExceptionsBundle());
+        bootstrap.addBundle(new JdbiExceptionsBundle());
 
         bootstrap.addBundle(new MigrationsBundle<PublicAuthConfiguration>() {
             @Override
@@ -73,7 +73,7 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
     public void run(PublicAuthConfiguration conf, Environment environment) {
         DataSourceFactory dataSourceFactory = conf.getDataSourceFactory();
 
-        jdbi = new DBIFactory().build(environment, dataSourceFactory, "postgresql");
+        jdbi = new JdbiFactory().build(environment, dataSourceFactory, "postgresql");
         initialiseMetrics(conf, environment);
 
         TokenService tokenService = new TokenService(conf.getTokensConfiguration());
@@ -115,7 +115,7 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
                 .start(GRAPHITE_SENDING_PERIOD_SECONDS, TimeUnit.SECONDS);
     }
 
-    public DBI getJdbi() {
+    public Jdbi getJdbi() {
         return jdbi;
     }
 

--- a/src/test/java/uk/gov/pay/publicauth/utils/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DropwizardAppWithPostgresRule.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.publicauth.utils;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.skife.jdbi.v2.DBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.commons.testing.db.PostgresDockerRule;
@@ -51,7 +51,7 @@ public class DropwizardAppWithPostgresRule implements TestRule {
         }, description);
     }
 
-    public DBI getJdbi() {
+    public Jdbi getJdbi() {
         return app.<PublicAuthApp>getApplication().getJdbi();
     }
 


### PR DESCRIPTION
## WHAT
- Upgrades dropwizard to v2.0.0 and jackson to latest version
- Added `dropwizard-dependencies` as parent as v2.0.0 upgrade doesn't specify transitive dependency versions anymore https://www.dropwizard.io/en/release-2.0.x/manual/upgrade-notes/upgrade-notes-2_0_x.html

    We can also include BOM for transitive dependency versions but versions can't be overridden and we may end up with multiple revisions of same library. For example, `jackson-version` current used is `2.10.2` but dropwizard uses `2.10.1`

- Upgraded dropwizard-sentry library too without which builds are failing with error `java.lang.NoSuchMethodError: 'com.google.common.collect.ImmutableList org.dhatim.dropwizard.sentry.logging.SentryAppenderFactory.getFilterFactories()'`

- Fixes/changes for AuthTokenDao as per JDBI v3
- Fixes for Test helpers for JDBI3 upgrade
