### PR TITLE
BAU: Allow overriding the database name

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -32,7 +32,7 @@ database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}
   password: ${DB_PASSWORD}
-  url: jdbc:postgresql://${DB_HOST}:5432/publicauth?sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory&${DB_SSL_OPTION}
+  url: jdbc:postgresql://${DB_HOST}:5432/${DB_NAME:-publicauth}?sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory&${DB_SSL_OPTION}
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
## WHAT
We might run into situations where the database name is not
`publicauth`.

This is the same we do for the other apps.

## HOW 
- Check everything works as usual