### PR TITLE
PP-6029 Add java buildpack manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,13 @@
+memory: 500M
+db_password: mysecretpassword
+db_user: products
+db_name: products
+db_ssl_option: ssl=none
+disk_quota: 500M
+disable_internal_https: 'true'
+run_migration: 'true'
+aws_access_key: x
+aws_secret_key: x
+token_api_hmac_secret: something
+token_db_bcrypt_salt: somethingelse
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,40 @@
+---
+applications:
+  - name: publicauth
+    buildpacks:
+      - java_buildpack
+    path: target/pay-publicauth-0.1-SNAPSHOT-allinone.jar
+    health-check-type: http
+    health-check-http-endpoint: '/healthcheck'
+    health-check-invocation-timeout: 5
+    memory: ((memory))
+    disk_quota: ((disk_quota))
+    env:
+      ADMIN_PORT: '9601'
+      DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
+      ENVIRONMENT: ((space))
+      JAVA_OPTS: -Xms512m -Xmx1G
+      JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+      JPA_LOG_LEVEL: 'INFO'
+      JPA_SQL_LOG_LEVEL: 'INFO'
+
+      TOKEN_DB_BCYPT_SALT: ((token_db_bcrypt_salt))
+      TOKEN_API_HMAC_SECRET: ((token_api_hmac_secret))
+
+      # Provide via publicauth-db service
+      DB_HOST: postgres-((space)).apps.internal
+      DB_NAME: ((db_name))
+      DB_PASSWORD: ((db_password))
+      DB_USER: ((db_user))
+      DB_SSL_OPTION: ((db_ssl_option))
+
+      AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
+
+      # Provide via Sentry service
+      SENTRY_DSN: noop://localhost
+
+      RUN_APP: 'true'
+      RUN_MIGRATION: ((run_migration))
+    routes:
+      - route: ((publicauth_route))


### PR DESCRIPTION
Adds a java buildpack manifest and dev.yml with common development
environment variables. To deploy into a PaaS space log into the space
and run the following from this project's root:

```
cf push --vars-file dev.yml \
  --var space=<space> \
  --var publicauth_route=pay-publicauth-<space>.london.cloudapps.digital

```


**How to test**
Push to your dev space. If its the first time you may need to delete the existing docker image based app with `cf delete publicauth` and then recreate the postgres network policy with
`cf add-network-policy publicauth --destination-app postgres --protocol tcp --port 5432` once the new buildpack based version of publicauth exists (likely it'll fail to start first time because it won't be able to connect to postgres).


