### PR TITLE
PP-6085 Correct env var name in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,7 +23,7 @@ applications:
       JPA_LOG_LEVEL: 'INFO'
       JPA_SQL_LOG_LEVEL: 'INFO'
 
-      TOKEN_DB_BCYPT_SALT: ((token_db_bcrypt_salt))
+      TOKEN_DB_BCRYPT_SALT: ((token_db_bcrypt_salt))
       TOKEN_API_HMAC_SECRET: ((token_api_hmac_secret))
 
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR


### PR DESCRIPTION
Correct the BCrypt salt env var name.

## WHAT
Check on staging that the name should be `TOKEN_DB_BCRYPT_SALT` with an 'R'.


