### PR TITLE
PP-6127: Bind CF app to credentials service

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,6 +12,7 @@ applications:
     disk_quota: ((disk_quota))
     services:
       - publicauth-db
+      - publicauth-secret-service
     env:
       ENV_MAP_BP_USE_APP_PROFILE_DIR: true
       ADMIN_PORT: '9601'


### PR DESCRIPTION
## WHAT
Binds the publicauth app running on PaaS to the publicauth-secret-service used to provision application creds added in alphagov/pay-omnibus#97.



