### PR TITLE
PP-6254 Add carbon-relay

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,7 @@ applications:
     services:
       - publicauth-db
       - publicauth-secret-service
+      - app-catalog
     env:
       ENV_MAP_BP_USE_APP_PROFILE_DIR: true
       ADMIN_PORT: '9601'
@@ -39,3 +40,7 @@ applications:
       DB_PASSWORD: ""
       DB_USER: ""
       DB_SSL_OPTION: ""
+
+      # Provided via the app-catalog service, see env-map.yml
+      METRICS_HOST: ""
+      METRICS_PORT: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -7,3 +7,5 @@ env_vars:
   TOKEN_DB_BCRYPT_SALT:  '.[][] | select(.name == "publicauth-secret-service") | .credentials.token_db_bcrypt_salt'
   TOKEN_API_HMAC_SECRET: '.[][] | select(.name == "publicauth-secret-service") | .credentials.token_api_hmac_secret'
   SENTRY_DSN:            '.[][] | select(.name == "publicauth-secret-service") | .credentials.sentry_dsn'
+  METRICS_HOST:          '.[][] | select(.name == "app-catalog")               | .credentials.carbon_relay_route'
+  METRICS_PORT:          '.[][] | select(.name == "app-catalog")               | .credentials.carbon_relay_port'


### PR DESCRIPTION
Set the `METRICS_HOST` and `METRICS_PORT` from the app-catalog to send
metrics to the carbon-relay app.

