### PR TITLE
PP-6763 - Remove direct debit smoke test from publicauth Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,10 +99,6 @@ pipeline {
          when { branch 'master' }
          steps { runCardSmokeTest() }
        }
-       stage('Direct Debit Smoke Test') {
-         when { branch 'master' }
-         steps { runDirectDebitSmokeTest() }
-       }
      }
    }
    stage('Complete') {


### PR DESCRIPTION
Description:
- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the publicauth Jenkins pipeline doesn't call the direct debit smoke Jenkins function


