### PR TITLE
PP-6763 - Remove direct debit smoke test from publicauth Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,18 +93,9 @@ pipeline {
      }
    }
    stage('Smoke Tests') {
-     failFast true
-     parallel {
-       stage('Card Smoke Test') {
-         when { branch 'master' }
-         steps { runCardSmokeTest() }
-       }
-       stage('Direct Debit Smoke Test') {
-         when { branch 'master' }
-         steps { runDirectDebitSmokeTest() }
-       }
+     when { branch 'master' }
+     steps { runCardSmokeTest() }
      }
-   }
    stage('Complete') {
      failFast true
      parallel {


### PR DESCRIPTION
Description:
- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the publicauth Jenkins pipeline doesn't call the direct debit smoke Jenkins function
