### PR TITLE
BAU fix mvn verify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,15 @@
                 <version>3.1.2</version>
                 <executions>
                     <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>false</failOnWarning>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-dependencies</id>
                         <phase>package</phase>
                         <goals>


### PR DESCRIPTION
## WHAT
- The pom references the dropwizard-dependencies as a parent which includes an execution rule for maven-dependency plugin:analyze-only setting the failOnWarning to true (the default is false). This plugin is run as part of the verify phase. We have undeclared transitive dependencies so the analyze-only goal fails and consequently the build.
