### PR TITLE
PP-7104 Use toString method of TokenLink to return value

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.publicauth.model.CreateTokenRequest;
 import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.TokenLink;
-import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.model.TokenSource;
 import uk.gov.pay.publicauth.model.TokenState;
 
@@ -66,7 +65,7 @@ public class AuthTokenDao {
         int rowsUpdated = jdbi.withHandle(handle ->
                 handle.createUpdate("UPDATE tokens SET description=:description WHERE token_link=:token_link AND revoked IS NULL")
                         .bind("description", newDescription)
-                        .bind("token_link", tokenLink.getValue()).execute());
+                        .bind("token_link", tokenLink.toString()).execute());
         return rowsUpdated > 0;
     }
 
@@ -75,7 +74,7 @@ public class AuthTokenDao {
                 handle.createUpdate("INSERT INTO tokens(token_hash, token_link, type, description, account_id, created_by, token_type) " +
                         "VALUES (:token_hash,:token_link,:type,:description,:account_id,:created_by,:token_type)")
                         .bind("token_hash", tokenHash.getValue())
-                        .bind("token_link", createTokenRequest.getTokenLink().getValue())
+                        .bind("token_link", createTokenRequest.getTokenLink().toString())
                         .bind("type", createTokenRequest.getTokenSource())
                         .bind("description", createTokenRequest.getDescription())
                         .bind("account_id", createTokenRequest.getAccountId())
@@ -101,7 +100,7 @@ public class AuthTokenDao {
         return jdbi.withHandle(handle ->
                 handle.createQuery("UPDATE tokens SET revoked=(now() at time zone 'utc') WHERE account_id=:account_id AND token_link=:token_link AND revoked IS NULL RETURNING to_char(revoked,'DD Mon YYYY')")
                         .bind("account_id", accountId)
-                        .bind("token_link", tokenLink.getValue())
+                        .bind("token_link", tokenLink.toString())
                         .mapTo(String.class)
                         .findFirst());
     }
@@ -114,7 +113,7 @@ public class AuthTokenDao {
                         "created_by, " +
                         "to_char(last_used,'DD Mon YYYY - HH24:MI') as last_used " +
                         "FROM tokens WHERE token_link = :token_link")
-                        .bind("token_link", tokenLink.getValue())
+                        .bind("token_link", tokenLink.toString())
                         .mapToMap().findFirst());
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenLink.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenLink.java
@@ -29,10 +29,6 @@ public class TokenLink {
 
     @Override
     public String toString() {
-        return "token_link " + tokenLink;
-    }
-
-    public String getValue() {
         return tokenLink;
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -89,7 +89,7 @@ public class PublicAuthResource {
 
         Tokens token = tokenService.issueTokens();
         authDao.storeToken(token.getHashedToken(), createTokenRequest);
-        LOGGER.info("Created token with {}", createTokenRequest.getTokenLink());
+        LOGGER.info("Created token with token_link {}", createTokenRequest.getTokenLink());
         return ok(ImmutableMap.of("token", token.getApiKey())).build();
     }
 
@@ -119,10 +119,10 @@ public class PublicAuthResource {
         String description = payload.get(DESCRIPTION_FIELD).asText();
 
         if (authDao.updateTokenDescription(tokenLink, description)) {
-            LOGGER.info("Updated description of token with {}", tokenLink);
+            LOGGER.info("Updated description of token with token_link {}", tokenLink);
             return authDao.findTokenByTokenLink(tokenLink)
                     .map(token -> ok(token).build())
-                    .orElseThrow(() -> new TokenNotFoundException("Could not update description of token with " + tokenLink));
+                    .orElseThrow(() -> new TokenNotFoundException("Could not update description of token with token_link " + tokenLink));
         }
 
         LOGGER.error("Could not update description of token with token_link " + tokenLink);
@@ -148,7 +148,7 @@ public class PublicAuthResource {
             TokenLink tokenLink = TokenLink.of(payload.get(TOKEN_LINK_FIELD).asText());
             return authDao.revokeSingleToken(accountId, tokenLink)
                     .map(this::buildRevokedTokenResponse)
-                    .orElseThrow(() -> new TokenNotFoundException("Could not revoke token with " + tokenLink));
+                    .orElseThrow(() -> new TokenNotFoundException("Could not revoke token with token_link " + tokenLink));
         }
 
     }

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
@@ -132,7 +132,7 @@ public class AuthTokenDaoIT {
         assertThat(tokens.size(), is(1));
 
         Map<String, Object> firstToken = tokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(TEST_USER_NAME_2));
@@ -152,7 +152,7 @@ public class AuthTokenDaoIT {
         assertThat(tokens.size(), is(1));
 
         Map<String, Object> firstToken = tokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.get("type"), is(API.toString()));
         assertThat(firstToken.containsKey("revoked"), is(false));
@@ -175,7 +175,7 @@ public class AuthTokenDaoIT {
 
         assertThat(tokens.size(), is(1));
         Map<String, Object> firstToken = tokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(firstToken.get("type"), is(API.toString()));
         assertThat(firstToken.containsKey("revoked"), is(true));
@@ -209,7 +209,7 @@ public class AuthTokenDaoIT {
         boolean updateResult = authTokenDao.updateTokenDescription(TOKEN_LINK, TOKEN_DESCRIPTION_2);
 
         assertThat(updateResult, is(true));
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION_2));
     }
 
@@ -220,7 +220,7 @@ public class AuthTokenDaoIT {
         Optional<Map<String, Object>> tokenMayBe = authTokenDao.findTokenByTokenLink(TOKEN_LINK);
         Map<String, Object> token = tokenMayBe.get();
 
-        assertThat(TOKEN_LINK.getValue(), is(token.get("token_link")));
+        assertThat(TOKEN_LINK.toString(), is(token.get("token_link")));
         assertThat(TOKEN_DESCRIPTION, is(token.get("description")));
         assertThat(TEST_USER_NAME, is(token.get("created_by")));
         assertThat(token.get("token_type"), is(DIRECT_DEBIT.toString()));
@@ -236,7 +236,7 @@ public class AuthTokenDaoIT {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, API, ACCOUNT_ID, TOKEN_DESCRIPTION, null, TEST_USER_NAME, now, null);
         Optional<Map<String, Object>> tokenMayBe = authTokenDao.findTokenByTokenLink(TOKEN_LINK);
         Map<String, Object> token = tokenMayBe.get();
-        assertThat(TOKEN_LINK.getValue(), is(token.get("token_link")));
+        assertThat(TOKEN_LINK.toString(), is(token.get("token_link")));
         assertThat(TOKEN_DESCRIPTION, is(token.get("description")));
         assertThat(TEST_USER_NAME, is(token.get("created_by")));
         assertThat(token.get("token_type"), is(CARD.toString()));
@@ -250,7 +250,7 @@ public class AuthTokenDaoIT {
         boolean updateResult = authTokenDao.updateTokenDescription(TOKEN_LINK, TOKEN_DESCRIPTION_2);
 
         assertThat(updateResult, is(false));
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.isPresent(), is(false));
     }
 
@@ -261,7 +261,7 @@ public class AuthTokenDaoIT {
         boolean updateResult = authTokenDao.updateTokenDescription(TOKEN_LINK, TOKEN_DESCRIPTION_2);
 
         assertThat(updateResult, is(false));
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
     }
 
@@ -273,7 +273,7 @@ public class AuthTokenDaoIT {
 
         assertThat(revokedDate.get(), is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
     }
 
@@ -285,7 +285,7 @@ public class AuthTokenDaoIT {
 
         assertThat(revokedDate.get(), is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
     }
     
@@ -298,7 +298,7 @@ public class AuthTokenDaoIT {
 
         assertThat(revokedDate.isPresent(), is(false));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(false));
     }
 
@@ -310,7 +310,7 @@ public class AuthTokenDaoIT {
 
         assertThat(revokedDate.isPresent(), is(false));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
     }
 

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
@@ -221,7 +221,7 @@ public class PublicAuthResourceIT {
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
         assertThat(firstToken.size(), is(7));
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.toString()));
         assertThat(firstToken.get("type"), is(API.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
@@ -232,7 +232,7 @@ public class PublicAuthResourceIT {
 
         Map<String, String> secondToken = retrievedTokens.get(1);
         assertThat(secondToken.size(), is(7));
-        assertThat(secondToken.get("token_link"), is(TOKEN_LINK.getValue()));
+        assertThat(secondToken.get("token_link"), is(TOKEN_LINK.toString()));
         assertThat(firstToken.get("type"), is(API.toString()));
         assertThat(secondToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(secondToken.containsKey("revoked"), is(false));
@@ -259,7 +259,7 @@ public class PublicAuthResourceIT {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(firstToken.get("revoked"), is(revoked.format(DATE_TIME_FORMAT)));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME));
@@ -285,7 +285,7 @@ public class PublicAuthResourceIT {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -293,7 +293,7 @@ public class PublicAuthResourceIT {
         assertThat(firstToken.get("type"), is(PRODUCTS.toString()));
         assertThat(firstToken.get("last_used"), is(lastUsed.format(DATE_TIME_FORMAT)));
         Map<String, String> secondToken = retrievedTokens.get(1);
-        assertThat(secondToken.get("token_link"), is(TOKEN_LINK.getValue()));
+        assertThat(secondToken.get("token_link"), is(TOKEN_LINK.toString()));
         assertThat(secondToken.get("description"), is(TOKEN_DESCRIPTION));
         assertThat(secondToken.containsKey("revoked"), is(false));
         assertThat(secondToken.get("created_by"), is(CREATED_USER_NAME));
@@ -317,7 +317,7 @@ public class PublicAuthResourceIT {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -341,7 +341,7 @@ public class PublicAuthResourceIT {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -364,7 +364,7 @@ public class PublicAuthResourceIT {
 
         //Retrieved in issued order from newest to oldest
         Map<String, String> firstToken = retrievedTokens.get(0);
-        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.getValue()));
+        assertThat(firstToken.get("token_link"), is(TOKEN_LINK_2.toString()));
         assertThat(firstToken.get("description"), is(TOKEN_DESCRIPTION_2));
         assertThat(firstToken.containsKey("revoked"), is(false));
         assertThat(firstToken.get("created_by"), is(CREATED_USER_NAME2));
@@ -377,14 +377,14 @@ public class PublicAuthResourceIT {
     public void respondWith400_ifNotProvidingDescription_whenUpdating() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.toString() + "\"}")
                 .statusCode(400)
                 .body("message", is("Missing fields: [description]"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.toString());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.toString()));
     }
 
     @Test
@@ -395,10 +395,10 @@ public class PublicAuthResourceIT {
                 .statusCode(400)
                 .body("message", is("Missing fields: [token_link]"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.toString());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.toString()));
     }
 
     @Test
@@ -409,10 +409,10 @@ public class PublicAuthResourceIT {
                 .statusCode(400)
                 .body("message", is("Missing fields: [token_link, description]"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.toString());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.toString()));
     }
 
     @Test
@@ -423,10 +423,10 @@ public class PublicAuthResourceIT {
                 .statusCode(400)
                 .body("message", is("Body cannot be empty"));
 
-        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> tokenLinkInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.toString());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
-        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.getValue()));
+        assertThat(tokenLinkInDb.get(), equalTo(TOKEN_LINK.toString()));
     }
 
     @Test
@@ -434,26 +434,26 @@ public class PublicAuthResourceIT {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
         ZonedDateTime nowFromDB = ZonedDateTime.now(ZoneOffset.UTC);
 
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.toString() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(200)
-                .body("token_link", is(TOKEN_LINK.getValue()))
+                .body("token_link", is(TOKEN_LINK.toString()))
                 .body("description", is(TOKEN_DESCRIPTION_2))
                 .body("issued_date", is(nowFromDB.format(DATE_TIME_FORMAT)))
                 .body("last_used", is(nowFromDB.format(DATE_TIME_FORMAT)))
                 .body("created_by", is(CREATED_USER_NAME))
                 .body("token_type", is(CARD.toString()));
 
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION_2));
     }
 
     @Test
     public void respondWith404_ifUpdatingDescriptionOfNonExistingToken() {
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.toString() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
                 .body("message", is("Could not update description of token with token_link " + TOKEN_LINK));
 
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.isPresent(), is(false));
     }
 
@@ -461,11 +461,11 @@ public class PublicAuthResourceIT {
     public void respondWith404_butDoNotUpdateRevokedTokens() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
-        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
+        updateTokenDescription("{\"token_link\" : \"" + TOKEN_LINK.toString() + "\", \"description\" : \"" + TOKEN_DESCRIPTION_2 + "\"}")
                 .statusCode(404)
                 .body("message", is("Could not update description of token with token_link " + TOKEN_LINK));
 
-        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.getValue());
+        Optional<String> descriptionInDb = app.getDatabaseHelper().lookupColumnForTokenTable("description", "token_link", TOKEN_LINK.toString());
         assertThat(descriptionInDb.get(), equalTo(TOKEN_DESCRIPTION));
     }
 
@@ -477,7 +477,7 @@ public class PublicAuthResourceIT {
                 .statusCode(400)
                 .body("message", is("Body cannot be empty"));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(false));
     }
 
@@ -489,7 +489,7 @@ public class PublicAuthResourceIT {
                 .statusCode(400)
                 .body("message", is("At least one of these fields must be present: [token_link, token]"));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(false));
     }
 
@@ -497,11 +497,11 @@ public class PublicAuthResourceIT {
     public void respondWith200_whenSingleTokenIsRevokedByTokenLink() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.toString() + "\"}")
                 .statusCode(200)
                 .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
     }
 
@@ -513,7 +513,7 @@ public class PublicAuthResourceIT {
                 .statusCode(200)
                 .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
 
-        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
     }
 
@@ -522,13 +522,13 @@ public class PublicAuthResourceIT {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, CREATED_USER_NAME);
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN_2, TOKEN_LINK_2, ACCOUNT_ID_2, TOKEN_DESCRIPTION, CREATED_USER_NAME);
 
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK_2.getValue() + "\"}")
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK_2.toString() + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token with " + TOKEN_LINK_2));
+                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK_2));
 
-        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(token1RevokedInDb.isPresent(), is(false));
-        Optional<String> token2RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK_2.getValue());
+        Optional<String> token2RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK_2.toString());
         assertThat(token2RevokedInDb.isPresent(), is(false));
     }
 
@@ -536,21 +536,21 @@ public class PublicAuthResourceIT {
     public void respondWith404_whenRevokingTokenAlreadyRevoked() {
         app.getDatabaseHelper().insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, ZonedDateTime.now(), CREATED_USER_NAME);
 
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.toString() + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token with " + TOKEN_LINK ));
+                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK ));
 
-        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.getValue());
+        Optional<String> token1RevokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(token1RevokedInDb.isPresent(), is(true));
     }
 
     @Test
     public void respondWith404_whenTokenDoesNotExist() {
-        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.getValue() + "\"}")
+        revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.toString() + "\"}")
                 .statusCode(404)
-                .body("message", is("Could not revoke token with " + TOKEN_LINK));
+                .body("message", is("Could not revoke token with token_link " + TOKEN_LINK));
 
-        Optional<String> tokenLinkdInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.getValue());
+        Optional<String> tokenLinkdInDb = app.getDatabaseHelper().lookupColumnForTokenTable("token_link", "token_link", TOKEN_LINK.toString());
         assertThat(tokenLinkdInDb.isPresent(), is(false));
     }
 

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -43,7 +43,7 @@ public class DatabaseTestHelper {
                 handle.createUpdate("INSERT INTO tokens(token_hash, token_link, type, account_id, description, token_type, revoked, created_by, last_used) " +
                         "VALUES (:token_hash,:token_link,:type,:account_id,:description,:token_type,(:revoked at time zone 'utc'), :created_by, (:last_used at time zone 'utc'))")
                         .bind("token_hash", tokenHash.getValue())
-                        .bind("token_link", randomTokenLink.getValue())
+                        .bind("token_link", randomTokenLink.toString())
                         .bind("type", tokenSource)
                         .bind("account_id", accountId)
                         .bind("description", description)


### PR DESCRIPTION
This is so that we can add a model to represent the token responses and use the Jackson `ToStringSerializer` to serialize TokenLinks in this response object.

The existing `toString` method returned the formatted string 'token_link <tokenLinkValue>'. Update log lines/exteption messages to include the 'token_link ' substring so that it can be removed from the `toString` method.
