### PR TITLE
PP-7104 Refactor to use TokenEntity object

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/dao/TokenMapper.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/TokenMapper.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.publicauth.dao;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import uk.gov.pay.publicauth.model.TokenEntity;
+import uk.gov.pay.publicauth.model.TokenLink;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
+import uk.gov.pay.publicauth.model.TokenSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+
+public class TokenMapper implements RowMapper<TokenEntity> {
+
+    @Override
+    public TokenEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+        TokenEntity.Builder tokenBuilder = new TokenEntity.Builder()
+                .withTokenLink(TokenLink.of(rs.getString("token_link")))
+                .withDescription(rs.getString("description"))
+                .withAccountId(rs.getString("account_id"))
+                .withTokenSource(TokenSource.valueOf(rs.getString("type")))
+                .withRevokedDate(getZonedDateTime(rs, "revoked").orElse(null))
+                .withIssuedDate(getZonedDateTime(rs, "issued").orElse(null))
+                .withLastUsedDate(getZonedDateTime(rs, "last_used").orElse(null))
+                .withCreatedBy(rs.getString(("created_by")))
+                .withTokenPaymentType(
+                        Optional.ofNullable(rs.getString("token_type"))
+                                .map(TokenPaymentType::valueOf)
+                                .orElse(TokenPaymentType.CARD));
+
+        return tokenBuilder.build();
+    }
+
+    private Optional<ZonedDateTime> getZonedDateTime(ResultSet rs, String columnLabel) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnLabel);
+
+        return Optional.ofNullable(timestamp)
+                .map(t -> ZonedDateTime.ofInstant(t.toInstant(), ZoneOffset.UTC));
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/json/DateTimeStringSerializer.java
+++ b/src/main/java/uk/gov/pay/publicauth/json/DateTimeStringSerializer.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.publicauth.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeStringSerializer extends StdSerializer<ZonedDateTime> {
+
+    public DateTimeStringSerializer() {
+        this(null);
+    }
+
+    private DateTimeStringSerializer(Class<ZonedDateTime> t) {
+        super(t);
+    }
+    
+    @Override
+    public void serialize(ZonedDateTime zonedDateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeString(DateTimeFormatter.ofPattern("dd MMM YYYY - HH:mm").format(zonedDateTime));
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenEntity.java
@@ -1,0 +1,128 @@
+package uk.gov.pay.publicauth.model;
+
+import java.time.ZonedDateTime;
+
+public class TokenEntity {
+    
+    private TokenLink tokenLink;
+    private String description;
+    private String accountId;
+    private TokenPaymentType tokenPaymentType;
+    private TokenSource tokenSource;
+    private ZonedDateTime revokedDate;
+    private ZonedDateTime issuedDate;
+    private ZonedDateTime lastUsedDate;
+    private String createdBy;
+    
+    public TokenEntity(Builder builder) {
+        this.tokenLink = builder.tokenLink;
+        this.description = builder.description;
+        this.accountId = builder.accountId;
+        this.tokenPaymentType = builder.tokenPaymentType;
+        this.tokenSource = builder.tokenSource;
+        this.revokedDate = builder.revokedDate;
+        this.issuedDate = builder.issuedDate;
+        this.lastUsedDate = builder.lastUsedDate;
+        this.createdBy = builder.createdBy;
+    }
+
+    public TokenLink getTokenLink() {
+        return tokenLink;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public TokenPaymentType getTokenPaymentType() {
+        return tokenPaymentType;
+    }
+
+    public TokenSource getTokenSource() {
+        return tokenSource;
+    }
+
+    public ZonedDateTime getRevokedDate() {
+        return revokedDate;
+    }
+
+    public ZonedDateTime getIssuedDate() {
+        return issuedDate;
+    }
+
+    public ZonedDateTime getLastUsedDate() {
+        return lastUsedDate;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public static final class Builder {
+        private TokenLink tokenLink;
+        private String description;
+        private String accountId;
+        private TokenPaymentType tokenPaymentType;
+        private TokenSource tokenSource;
+        private ZonedDateTime revokedDate;
+        private ZonedDateTime issuedDate;
+        private ZonedDateTime lastUsedDate;
+        private String createdBy;
+
+        public Builder() {
+        }
+
+        public Builder withTokenLink(TokenLink tokenLink) {
+            this.tokenLink = tokenLink;
+            return this;
+        }
+
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+        
+        public Builder withAccountId(String accountId) {
+            this.accountId = accountId;
+            return this;
+        }
+
+        public Builder withTokenPaymentType(TokenPaymentType tokenPaymentType) {
+            this.tokenPaymentType = tokenPaymentType;
+            return this;
+        }
+
+        public Builder withTokenSource(TokenSource tokenSource) {
+            this.tokenSource = tokenSource;
+            return this;
+        }
+
+        public Builder withRevokedDate(ZonedDateTime revokedDate) {
+            this.revokedDate = revokedDate;
+            return this;
+        }
+
+        public Builder withIssuedDate(ZonedDateTime issuedDate) {
+            this.issuedDate = issuedDate;
+            return this;
+        }
+
+        public Builder withLastUsedDate(ZonedDateTime lastUsedDate) {
+            this.lastUsedDate = lastUsedDate;
+            return this;
+        }
+        
+        public Builder withCreatedBy(String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        public TokenEntity build() {
+            return new TokenEntity(this);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenResponse.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.publicauth.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.publicauth.json.DateTimeStringSerializer;
+
+import java.time.ZonedDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TokenResponse {
+    
+    @JsonProperty("token_link")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private TokenLink tokenLink;
+    
+    @JsonProperty("description")
+    private String description;
+    
+    @JsonProperty("token_type")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private TokenPaymentType tokenPaymentType;
+    
+    @JsonProperty("type")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private TokenSource tokenSource;
+    
+    @JsonProperty("revoked")
+    @JsonSerialize(using = DateTimeStringSerializer.class)
+    private ZonedDateTime revokedDate;
+    
+    @JsonProperty("issued_date")
+    @JsonSerialize(using = DateTimeStringSerializer.class)
+    private ZonedDateTime issuedDate;
+    
+    @JsonProperty("last_used")
+    @JsonSerialize(using = DateTimeStringSerializer.class)
+    private ZonedDateTime lastUsedDate;
+    
+    @JsonProperty("created_by")
+    private String createdBy;
+
+    public TokenResponse(TokenLink tokenLink,
+                         String description,
+                         TokenPaymentType tokenPaymentType,
+                         TokenSource tokenSource,
+                         ZonedDateTime revokedDate,
+                         ZonedDateTime issuedDate,
+                         ZonedDateTime lastUsedDate,
+                         String createdBy) {
+        this.tokenLink = tokenLink;
+        this.description = description;
+        this.tokenPaymentType = tokenPaymentType;
+        this.tokenSource = tokenSource;
+        this.revokedDate = revokedDate;
+        this.issuedDate = issuedDate;
+        this.lastUsedDate = lastUsedDate;
+        this.createdBy = createdBy;
+    }
+    
+    public static TokenResponse fromEntity(TokenEntity tokenEntity) {
+        return new TokenResponse(
+                tokenEntity.getTokenLink(),
+                tokenEntity.getDescription(),
+                tokenEntity.getTokenPaymentType(),
+                tokenEntity.getTokenSource(),
+                tokenEntity.getRevokedDate(),
+                tokenEntity.getIssuedDate(),
+                tokenEntity.getLastUsedDate(),
+                tokenEntity.getCreatedBy()
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -6,11 +6,11 @@ import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.model.TokenSource;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static java.sql.Timestamp.from;
+import static java.time.ZoneOffset.UTC;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
 import static uk.gov.pay.publicauth.model.TokenSource.API;
 
@@ -23,11 +23,11 @@ public class DatabaseTestHelper {
     }
 
     public void insertAccount(TokenHash tokenHash, TokenLink randomTokenLink, String accountId, String description, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
+        insertAccount(tokenHash, randomTokenLink, accountId, description, null, createdBy, ZonedDateTime.now(UTC));
     }
 
     public void insertAccount(TokenHash tokenHash, TokenLink randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy) {
-        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, ZonedDateTime.now(ZoneOffset.UTC));
+        insertAccount(tokenHash, randomTokenLink, accountId, description, revoked, createdBy, ZonedDateTime.now(UTC));
     }
 
     public void insertAccount(TokenHash tokenHash, TokenLink randomTokenLink, String accountId, String description, ZonedDateTime revoked, String createdBy, ZonedDateTime lastUsed) {
@@ -88,6 +88,7 @@ public class DatabaseTestHelper {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT (now() at time zone 'utc')")
                         .mapTo(ZonedDateTime.class)
-                        .first());
+                        .first())
+                        .withZoneSameInstant(UTC);
     }
 }


### PR DESCRIPTION
Add `TokenEntity` object to represent a `token` retrieved from the database. For now, insertion doesn't use this entity.

This is to replace returning Maps from the DAO.

Add a `TokenResponse` object to represent the response to requests to get a token/tokens to replace building the response using a map.


