### PR TITLE
PP-7104 Move code from resource to service

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
+++ b/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
@@ -76,7 +76,8 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
         jdbi = new JdbiFactory().build(environment, dataSourceFactory, "postgresql");
         initialiseMetrics(conf, environment);
 
-        TokenService tokenService = new TokenService(conf.getTokensConfiguration());
+        AuthTokenDao authTokenDao = new AuthTokenDao(jdbi);
+        TokenService tokenService = new TokenService(conf.getTokensConfiguration(), authTokenDao);
 
         environment.jersey().register(new AuthDynamicFeature(
                 new OAuthCredentialAuthFilter.Builder<Token>()

--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -10,6 +10,7 @@ import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenSource;
 import uk.gov.pay.publicauth.model.TokenState;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -87,21 +88,21 @@ public class AuthTokenDao {
         }
     }
 
-    public Optional<String> revokeSingleToken(String accountId, TokenHash tokenHash) {
+    public Optional<ZonedDateTime> revokeSingleToken(String accountId, TokenHash tokenHash) {
         return Optional.ofNullable(jdbi.withHandle(handle ->
-                handle.createQuery("UPDATE tokens SET revoked=(now() at time zone 'utc') WHERE account_id=:account_id AND token_hash=:token_hash AND revoked IS NULL RETURNING to_char(revoked,'DD Mon YYYY')")
+                handle.createQuery("UPDATE tokens SET revoked=(now() at time zone 'utc') WHERE account_id=:account_id AND token_hash=:token_hash AND revoked IS NULL RETURNING revoked")
                         .bind("account_id", accountId)
                         .bind("token_hash", tokenHash.getValue())
-                        .mapTo(String.class)
+                        .mapTo(ZonedDateTime.class)
                         .first()));
     }
 
-    public Optional<String> revokeSingleToken(String accountId, TokenLink tokenLink) {
+    public Optional<ZonedDateTime> revokeSingleToken(String accountId, TokenLink tokenLink) {
         return jdbi.withHandle(handle ->
-                handle.createQuery("UPDATE tokens SET revoked=(now() at time zone 'utc') WHERE account_id=:account_id AND token_link=:token_link AND revoked IS NULL RETURNING to_char(revoked,'DD Mon YYYY')")
+                handle.createQuery("UPDATE tokens SET revoked=(now() at time zone 'utc') WHERE account_id=:account_id AND token_link=:token_link AND revoked IS NULL RETURNING revoked")
                         .bind("account_id", accountId)
                         .bind("token_link", tokenLink.toString())
-                        .mapTo(String.class)
+                        .mapTo(ZonedDateTime.class)
                         .findFirst());
     }
 

--- a/src/main/java/uk/gov/pay/publicauth/exception/TokenNotFoundException.java
+++ b/src/main/java/uk/gov/pay/publicauth/exception/TokenNotFoundException.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.publicauth.exception;
 
-public class TokenNotFoundException extends Throwable {
+public class TokenNotFoundException extends RuntimeException {
 
     public TokenNotFoundException(String message) {
         super(message);

--- a/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
@@ -8,10 +8,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.publicauth.app.config.TokensConfiguration;
 import uk.gov.pay.publicauth.auth.Token;
+import uk.gov.pay.publicauth.dao.AuthTokenDao;
+import uk.gov.pay.publicauth.exception.TokenNotFoundException;
+import uk.gov.pay.publicauth.model.CreateTokenRequest;
 import uk.gov.pay.publicauth.model.TokenHash;
+import uk.gov.pay.publicauth.model.TokenLink;
+import uk.gov.pay.publicauth.model.TokenResponse;
+import uk.gov.pay.publicauth.model.TokenSource;
+import uk.gov.pay.publicauth.model.TokenState;
 import uk.gov.pay.publicauth.model.Tokens;
 
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static uk.gov.pay.publicauth.service.RandomIdGenerator.RANDOM_ID_MAX_LENGTH;
 import static uk.gov.pay.publicauth.service.RandomIdGenerator.RANDOM_ID_MIN_LENGTH;
@@ -27,18 +37,27 @@ public class TokenService {
 
     private final String encryptDBSalt;
     private final String apiKeyHmacSecret;
+    private final AuthTokenDao authTokenDao;
 
-    public TokenService(TokensConfiguration config) {
+    public TokenService(TokensConfiguration config, AuthTokenDao authTokenDao) {
         this.encryptDBSalt = config.getEncryptDBSalt();
         this.apiKeyHmacSecret = config.getApiKeyHmacSecret();
+        this.authTokenDao = authTokenDao;
     }
 
+    public String createTokenForAccount(CreateTokenRequest createTokenRequest) {
+        Tokens tokens = issueTokens();
+        authTokenDao.storeToken(tokens.getHashedToken(), createTokenRequest);
+        LOGGER.info("Created token with token_link {}", createTokenRequest.getTokenLink());
+        return tokens.getApiKey();
+    }
+    
     /**
      * Tokens includes:
      * - Salted BCrypt Hash. Intended to be used as encrypted value when storing in DB
      * - Token + Hmac(Token + SecretKey). To be used as API key
      */
-    public Tokens issueTokens() {
+    private Tokens issueTokens() {
         final String newId = newId();
         return new Tokens(encrypt(newId), createApiKey(newId));
     }
@@ -49,20 +68,6 @@ public class TokenService {
      * - Extract Token, check Hmac and encrypt.
      */
     public Optional<Token> extractEncryptedTokenFrom(String apiKey) {
-        return extractAndEncryptTokenFrom(apiKey);
-    }
-
-    private TokenHash encrypt(String token) {
-        return TokenHash.of(BCrypt.hashpw(token, encryptDBSalt));
-    }
-
-    private String createApiKey(String token) {
-        byte[] hmacBytes = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, apiKeyHmacSecret).hmac(token);
-        String encodedHmac = BaseEncoding.base32Hex().lowerCase().omitPadding().encode(hmacBytes);
-        return token + encodedHmac;
-    }
-
-    private Optional<Token> extractAndEncryptTokenFrom(String apiKey) {
         if (isValidLength(apiKey)) {
             int initHmacIndex = apiKey.length() - HMAC_SHA1_LENGTH;
             String hmacFromApiKey = apiKey.substring(initHmacIndex);
@@ -75,6 +80,44 @@ public class TokenService {
 
         LOGGER.error("Authorisation failure - token extraction from key failed");
         return Optional.empty();
+    }
+    
+    public List<TokenResponse> findTokensBy(String accountId, TokenState tokenState, TokenSource tokenSource) {
+        return authTokenDao.findTokensBy(accountId, tokenState, tokenSource)
+                .stream()
+                .map(TokenResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public TokenResponse updateTokenDescription(TokenLink tokenLink, String description) {
+        if (authTokenDao.updateTokenDescription(tokenLink, description)) {
+            LOGGER.info("Updated description of token with token_link {}", tokenLink);
+            return authTokenDao.findTokenByTokenLink(tokenLink).map(TokenResponse::fromEntity)
+                    .orElseThrow(() -> new TokenNotFoundException("Could not update description of token with token_link " + tokenLink));
+        }
+
+        LOGGER.error("Could not update description of token with token_link " + tokenLink);
+        throw new TokenNotFoundException("Could not update description of token with token_link " + tokenLink);
+    }
+
+    public ZonedDateTime revokeToken(String accountId, TokenHash tokenHash) {
+        return authTokenDao.revokeSingleToken(accountId, tokenHash)
+                .orElseThrow(() -> new TokenNotFoundException("Could not revoke token"));
+    }
+    
+    public ZonedDateTime revokeToken(String accountId, TokenLink tokenLink) {
+        return authTokenDao.revokeSingleToken(accountId, tokenLink)
+                .orElseThrow(() -> new TokenNotFoundException("Could not revoke token with token_link " + tokenLink));
+    }
+
+    private TokenHash encrypt(String token) {
+        return TokenHash.of(BCrypt.hashpw(token, encryptDBSalt));
+    }
+
+    private String createApiKey(String token) {
+        byte[] hmacBytes = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, apiKeyHmacSecret).hmac(token);
+        String encodedHmac = BaseEncoding.base32Hex().lowerCase().omitPadding().encode(hmacBytes);
+        return token + encodedHmac;
     }
 
     private boolean tokenMatchesHmac(String token, String currentHmac) {

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
@@ -14,7 +14,6 @@ import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -266,9 +265,9 @@ public class AuthTokenDaoIT {
     public void shouldRevokeASingleTokenByTokenLink() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
-        Optional<String> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
+        Optional<ZonedDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
 
-        assertThat(revokedDate.get(), is(ZonedDateTime.now(UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
+        assertThat(revokedDate.get(), isCloseTo(ZonedDateTime.now(UTC)));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
@@ -278,9 +277,9 @@ public class AuthTokenDaoIT {
     public void shouldRevokeASingleTokenByTokenHash() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
-        Optional<String> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_HASH);
+        Optional<ZonedDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_HASH);
 
-        assertThat(revokedDate.get(), is(ZonedDateTime.now(UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
+        assertThat(revokedDate.get(), isCloseTo(ZonedDateTime.now(UTC)));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
@@ -291,7 +290,7 @@ public class AuthTokenDaoIT {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID_2, TOKEN_DESCRIPTION_2, TEST_USER_NAME);
 
-        Optional<String> revokedDate  = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK_2);
+        Optional<ZonedDateTime> revokedDate  = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK_2);
 
         assertThat(revokedDate.isPresent(), is(false));
 
@@ -303,7 +302,7 @@ public class AuthTokenDaoIT {
     public void shouldNotRevokeATokenAlreadyRevoked() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION,  ZonedDateTime.now(UTC), TEST_USER_NAME);
 
-        Optional<String> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
+        Optional<ZonedDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
 
         assertThat(revokedDate.isPresent(), is(false));
 


### PR DESCRIPTION
Move code that accesses the DAO from `PublicAuthResource` into `TokenService`. Next step will be to alter the authorise resource method in order to completely remove accessing the DAO from the resource.

