### PR TITLE
PP-7104 Return token_link from authorisation requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>
+            <groupId>uk.gov.pay</groupId>
+            <artifactId>model</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>

--- a/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
+++ b/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
@@ -25,7 +25,10 @@ import uk.gov.pay.publicauth.app.config.PublicAuthConfiguration;
 import uk.gov.pay.publicauth.auth.Token;
 import uk.gov.pay.publicauth.auth.TokenAuthenticator;
 import uk.gov.pay.publicauth.dao.AuthTokenDao;
+import uk.gov.pay.publicauth.exception.TokenInvalidException;
+import uk.gov.pay.publicauth.exception.TokenInvalidExceptionMapper;
 import uk.gov.pay.publicauth.exception.TokenNotFoundExceptionMapper;
+import uk.gov.pay.publicauth.exception.TokenRevokedExceptionMapper;
 import uk.gov.pay.publicauth.exception.ValidationExceptionMapper;
 import uk.gov.pay.publicauth.filters.LoggingMDCRequestFilter;
 import uk.gov.pay.publicauth.filters.LoggingMDCResponseFilter;
@@ -85,11 +88,12 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
                         .setPrefix("Bearer")
                         .buildAuthFilter()));
         environment.jersey().register(new AuthValueFactoryProvider.Binder<>(Token.class));
-
-        environment.jersey().register(new PublicAuthResource(new AuthTokenDao(jdbi), tokenService));
+        environment.jersey().register(new PublicAuthResource(tokenService));
         environment.jersey().register(new HealthCheckResource(environment));
         environment.jersey().register(new ValidationExceptionMapper());
         environment.jersey().register(new TokenNotFoundExceptionMapper());
+        environment.jersey().register(new TokenInvalidExceptionMapper());
+        environment.jersey().register(new TokenRevokedExceptionMapper());
         environment.healthChecks().register("database", new DatabaseHealthCheck(conf.getDataSourceFactory()));
 
         environment.jersey().register(new LoggingMDCRequestFilter());

--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -27,20 +27,16 @@ public class AuthTokenDao {
         this.jdbi = jdbi;
     }
 
-    public Optional<TokenEntity> findUnRevokedAccount(TokenHash tokenHash) {
-        Optional<TokenEntity> storedTokenHash = jdbi.withHandle(handle ->
-                handle.createQuery(TOKEN_SELECT +
-                        "WHERE token_hash = :token_hash AND revoked IS NULL")
-                        .bind("token_hash", tokenHash.getValue())
-                        .map(new TokenMapper())
-                        .findFirst());
-        if (storedTokenHash.isPresent()) {
-            updateLastUsedTime(tokenHash);
-        }
-        return storedTokenHash;
+    public Optional<TokenEntity> findTokenByHash(TokenHash tokenHash) {
+        return jdbi.withHandle(handle ->
+                    handle.createQuery(TOKEN_SELECT +
+                            "WHERE token_hash = :token_hash")
+                            .bind("token_hash", tokenHash.getValue())
+                            .map(new TokenMapper())
+                            .findFirst());
     }
 
-    private void updateLastUsedTime(TokenHash tokenHash) {
+    public void updateLastUsedTime(TokenHash tokenHash) {
         jdbi.withHandle(handle ->
                 handle.createUpdate("UPDATE tokens SET last_used=(now() at time zone 'utc') WHERE token_hash=:token_hash")
                         .bind("token_hash", tokenHash.getValue())

--- a/src/main/java/uk/gov/pay/publicauth/exception/TokenInvalidException.java
+++ b/src/main/java/uk/gov/pay/publicauth/exception/TokenInvalidException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.publicauth.exception;
+
+public class TokenInvalidException extends RuntimeException {
+    
+    public TokenInvalidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/exception/TokenInvalidExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/publicauth/exception/TokenInvalidExceptionMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.publicauth.exception;
+
+import uk.gov.pay.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.Map;
+
+public class TokenInvalidExceptionMapper implements ExceptionMapper<TokenInvalidException> {
+    @Override
+    public Response toResponse(TokenInvalidException e) {
+        return Response.status(Response.Status.UNAUTHORIZED)
+                .entity(Map.of(
+                        "message", e.getMessage(),
+                        "error_identifier", ErrorIdentifier.AUTH_TOKEN_INVALID
+                ))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/exception/TokenRevokedException.java
+++ b/src/main/java/uk/gov/pay/publicauth/exception/TokenRevokedException.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.publicauth.exception;
+
+import uk.gov.pay.publicauth.model.TokenLink;
+
+import static java.lang.String.format;
+
+public class TokenRevokedException extends RuntimeException {
+    private TokenLink tokenLink;
+
+    public TokenRevokedException(TokenLink tokenLink) {
+        super(format("Token with token_link %s has been revoked", tokenLink));
+        this.tokenLink = tokenLink;
+    }
+
+    public TokenLink getTokenLink() {
+        return tokenLink;
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/exception/TokenRevokedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/publicauth/exception/TokenRevokedExceptionMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.publicauth.exception;
+
+import uk.gov.pay.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.Map;
+
+public class TokenRevokedExceptionMapper implements ExceptionMapper<TokenRevokedException> {
+    @Override
+    public Response toResponse(TokenRevokedException e) {
+        return Response.status(Response.Status.UNAUTHORIZED)
+                .entity(Map.of(
+                        "message", e.getMessage(),
+                        "token_link", e.getTokenLink().toString(),
+                        "error_identifier", ErrorIdentifier.AUTH_TOKEN_REVOKED
+                ))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/AuthResponse.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/AuthResponse.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.publicauth.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+public class AuthResponse {
+    
+    @JsonProperty("account_id")
+    private String accountId;
+
+    @JsonProperty("token_link")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private TokenLink tokenLink;
+    
+    @JsonProperty("token_type")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private TokenPaymentType tokenPaymentType;
+
+    public AuthResponse(String accountId, TokenLink tokenLink, TokenPaymentType tokenPaymentType) {
+        this.tokenLink = tokenLink;
+        this.accountId = accountId;
+        this.tokenPaymentType = tokenPaymentType;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public TokenLink getTokenLink() {
+        return tokenLink;
+    }
+
+    public TokenPaymentType getTokenPaymentType() {
+        return tokenPaymentType;
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenEntity.java
@@ -3,7 +3,7 @@ package uk.gov.pay.publicauth.model;
 import java.time.ZonedDateTime;
 
 public class TokenEntity {
-    
+
     private TokenLink tokenLink;
     private String description;
     private String accountId;
@@ -13,7 +13,27 @@ public class TokenEntity {
     private ZonedDateTime issuedDate;
     private ZonedDateTime lastUsedDate;
     private String createdBy;
-    
+
+    public TokenEntity(TokenLink tokenLink,
+                       String description,
+                       String accountId,
+                       TokenPaymentType tokenPaymentType,
+                       TokenSource tokenSource,
+                       ZonedDateTime revokedDate,
+                       ZonedDateTime issuedDate,
+                       ZonedDateTime lastUsedDate,
+                       String createdBy) {
+        this.tokenLink = tokenLink;
+        this.description = description;
+        this.accountId = accountId;
+        this.tokenPaymentType = tokenPaymentType;
+        this.tokenSource = tokenSource;
+        this.revokedDate = revokedDate;
+        this.issuedDate = issuedDate;
+        this.lastUsedDate = lastUsedDate;
+        this.createdBy = createdBy;
+    }
+
     public TokenEntity(Builder builder) {
         this.tokenLink = builder.tokenLink;
         this.description = builder.description;
@@ -85,7 +105,7 @@ public class TokenEntity {
             this.description = description;
             return this;
         }
-        
+
         public Builder withAccountId(String accountId) {
             this.accountId = accountId;
             return this;
@@ -115,7 +135,7 @@ public class TokenEntity {
             this.lastUsedDate = lastUsedDate;
             return this;
         }
-        
+
         public Builder withCreatedBy(String createdBy) {
             this.createdBy = createdBy;
             return this;

--- a/src/test/java/uk/gov/pay/publicauth/fixture/TokenEntityFixture.java
+++ b/src/test/java/uk/gov/pay/publicauth/fixture/TokenEntityFixture.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.publicauth.fixture;
+
+import uk.gov.pay.publicauth.model.TokenEntity;
+import uk.gov.pay.publicauth.model.TokenLink;
+import uk.gov.pay.publicauth.model.TokenPaymentType;
+import uk.gov.pay.publicauth.model.TokenSource;
+
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
+import static uk.gov.pay.publicauth.model.TokenSource.API;
+
+public class TokenEntityFixture {
+    private TokenLink tokenLink = TokenLink.of("123456789101112131415161718192021222");
+    private String description = "token description";
+    private String accountId = "42";
+    private TokenPaymentType tokenPaymentType = CARD;
+    private TokenSource tokenSource = API;
+    private ZonedDateTime revokedDate;
+    private ZonedDateTime issuedDate = ZonedDateTime.parse("2020-01-01T12:30:00.000Z");
+    private ZonedDateTime lastUsedDate;
+    private String createdBy = "a-user-id";
+
+    private TokenEntityFixture() {
+    }
+    
+    public static TokenEntityFixture aTokenEntity() {
+        return new TokenEntityFixture();
+    }
+
+    public TokenEntityFixture withTokenLink(TokenLink tokenLink) {
+        this.tokenLink = tokenLink;
+        return this;
+    }
+
+    public TokenEntityFixture withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public TokenEntityFixture withAccountId(String accountId) {
+        this.accountId = accountId;
+        return this;
+    }
+
+    public TokenEntityFixture withTokenPaymentType(TokenPaymentType tokenPaymentType) {
+        this.tokenPaymentType = tokenPaymentType;
+        return this;
+    }
+
+    public TokenEntityFixture withTokenSource(TokenSource tokenSource) {
+        this.tokenSource = tokenSource;
+        return this;
+    }
+
+    public TokenEntityFixture withRevokedDate(ZonedDateTime revokedDate) {
+        this.revokedDate = revokedDate;
+        return this;
+    }
+
+    public TokenEntityFixture withIssuedDate(ZonedDateTime issuedDate) {
+        this.issuedDate = issuedDate;
+        return this;
+    }
+
+    public TokenEntityFixture withLastUsedDate(ZonedDateTime lastUsedDate) {
+        this.lastUsedDate = lastUsedDate;
+        return this;
+    }
+
+    public TokenEntityFixture withCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+        return this;
+    }
+
+    public TokenEntity build() {
+        return new TokenEntity(
+                this.tokenLink,
+                this.description,
+                this.accountId,
+                this.tokenPaymentType,
+                this.tokenSource,
+                this.revokedDate,
+                this.issuedDate,
+                this.lastUsedDate,
+                this.createdBy);
+    }
+}


### PR DESCRIPTION
Return token_link for a successful authorisation request so it can be
logged by public api.

For an authorisation attempt for a revoked token, respond with a 401
status and body containing error_identifier AUTH_TOKEN_REVOKED with the
token_link in the body so this can be logged by public api,

For an authorisation attempt for a non-existent token, respond with a
401 status and body containing error_identifier AUTH_TOKEN_INVALID


