### PR TITLE
PP-7104 Update pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>2.11.0</jackson.version>
-        <dropwizard.version>2.0.10</dropwizard.version>
-        <guava.version>29.0-jre</guava.version>
-        <pay-java-commons.version>1.0.20200702150539</pay-java-commons.version>
+        <dropwizard.version>2.0.15</dropwizard.version>
+        <guava.version>30.0-jre</guava.version>
+        <pay-java-commons.version>1.0.20201103173727</pay-java-commons.version>
     </properties>
     <repositories>
         <repository>
@@ -86,13 +86,6 @@
             <version>0.4</version>
         </dependency>
         <dependency>
-            <!-- this has been added so we can use org.apache.http.conn.ssl.DefaultHostnameVerifier for Postgres.
-                it does not work with dropwizard 0.8.x but publicauth doesn't perform any outgoing HTTP calls -->
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
@@ -155,16 +148,6 @@
             <artifactId>testing</artifactId>
             <version>${pay-java-commons.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Bump dropwizard and pay-java-commons version at the same time, otherwise
there is a dependency clash.

Remove some unused dependencies.

