### PR TITLE
PP-5236 Add token account type param to create request

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
@@ -17,18 +17,21 @@ public class CreateTokenRequest {
     private final TokenPaymentType tokenPaymentType;
     private final TokenSource tokenSource;
     private final TokenLink tokenLink = TokenLink.of(randomUUID().toString());
+    private final TokenAccountType tokenAccountType;
 
     @JsonCreator
     public CreateTokenRequest(@JsonProperty("account_id") String accountId,
                               @JsonProperty("description") String description,
                               @JsonProperty("created_by") String createdBy,
                               @JsonProperty("token_type") TokenPaymentType tokenPaymentType,
-                              @JsonProperty("type") TokenSource tokenSource) {
+                              @JsonProperty("type") TokenSource tokenSource,
+                              @JsonProperty("token_account_type") TokenAccountType tokenAccountType) {
         this.accountId = accountId;
         this.description = description;
         this.createdBy = createdBy;
         this.tokenPaymentType = tokenPaymentType == null ? CARD : tokenPaymentType;
         this.tokenSource = tokenSource == null ? API : tokenSource;
+        this.tokenAccountType = tokenAccountType;
     }
 
     public String getAccountId() {
@@ -53,5 +56,9 @@ public class CreateTokenRequest {
 
     public TokenLink getTokenLink() {
         return tokenLink;
+    }
+
+    public TokenAccountType getTokenAccountType() {
+        return tokenAccountType;
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenAccountType.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenAccountType.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.publicauth.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum TokenAccountType {
+    LIVE, TEST;
+
+    @JsonCreator
+    public static TokenAccountType fromString(String type) {
+        return TokenAccountType.valueOf(type.toUpperCase());
+    }
+}

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
@@ -10,6 +10,7 @@ import uk.gov.pay.publicauth.model.CreateTokenRequest;
 import uk.gov.pay.publicauth.model.TokenEntity;
 import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.TokenLink;
+import uk.gov.pay.publicauth.model.TokenAccountType;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
 import java.time.ZonedDateTime;
@@ -171,7 +172,7 @@ public class AuthTokenDaoIT {
 
     @Test
     public void shouldInsertNewToken() {
-        var createTokenRequest = new CreateTokenRequest("account-id", "description", "user", CARD, API);
+        var createTokenRequest = new CreateTokenRequest("account-id", "description", "user", CARD, API, TokenAccountType.LIVE);
         authTokenDao.storeToken(TokenHash.of("token-hash"), createTokenRequest);
         Map<String, Object> tokenByHash = app.getDatabaseHelper().getTokenByHash(TokenHash.of("token-hash"));
         ZonedDateTime now = app.getDatabaseHelper().getCurrentTime();
@@ -302,7 +303,7 @@ public class AuthTokenDaoIT {
     public void shouldErrorIfTriesToSaveTheSameTokenTwice() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
-        var createTokenRequest = new CreateTokenRequest(ACCOUNT_ID, TOKEN_DESCRIPTION, "test@email.com", CARD, API);
+        var createTokenRequest = new CreateTokenRequest(ACCOUNT_ID, TOKEN_DESCRIPTION, "test@email.com", CARD, API, TokenAccountType.LIVE);
         authTokenDao.storeToken(TOKEN_HASH, createTokenRequest);
     }
 

--- a/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.publicauth.model.CreateTokenRequest;
 import uk.gov.pay.publicauth.model.TokenEntity;
 import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.TokenLink;
+import uk.gov.pay.publicauth.model.TokenAccountType;
 
 import java.util.List;
 import java.util.Optional;
@@ -104,7 +105,7 @@ public class TokenServiceTest {
 
     @Test
     public void shouldCreateValidToken() {
-        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API);
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, null);
         String apiKey = tokenService.createTokenForAccount(createTokenRequest);
 
         // Minimum length guarantee is 32 for Hmac and an extremely very unlikely
@@ -134,7 +135,7 @@ public class TokenServiceTest {
 
     @Test
     public void shouldCreateDifferentTokensWhenCalledTwice() {
-        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API);
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.LIVE);
         String apiKey1 = tokenService.createTokenForAccount(createTokenRequest);
         String apiKey2 = tokenService.createTokenForAccount(createTokenRequest);
 


### PR DESCRIPTION
Parse `token_account_type` param in the create api key request body.
This could then be used by the API key generation algorithm when
prefixing the token.

This should be optional, if no param is provided the key should still be
created.

If anything other than 'live', 'LIVE', 'test', 'TEST' is provided the
request should `400`.

