### PR TITLE
PP-5236 Optionally prefix API key tokens with human readable string

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Payments Public API Authentication Service
 Anatomy of an api key:
 
 ```
-u3tl8gajo9paj0xki31jm1psr3v21m5urh50zoa7a262w4ntzoo6cqhu82
-`------------------------------'`------------------------'
-       TOKEN                          CHECKSUM
+govukpay_live_u3tl8gajo9paj0xki31jm1psr3v21m5urh50zoa7a262w4ntzoo6cqhu82
+`------------`'------------------------------'
+   PREFIX           RANDOM BASE32 STRING
+`--------------------------------------------'`------------------------'
+                   TOKEN                        CHECKSUM
 ```
 
 | Item | Definition |
-|------|------------|
-| `TOKEN` | randomly generated base 32 string, 130 bits entropy, variable length |
+|------|------------|"
+| `TOKEN` | randomly generated base 32 string, 130 bits entropy, variable length, optionally includes a human readable prefix |
 | `CHECKSUM` | `hmacSha1(TOKEN + TOKEN_API_HMAC_SECRET)`, base32 encoded. Always 32 characters long |
 | `TOKEN_API_HMAC_SECRET` | secret provided via application environment |
 | `TOKEN_DB_BCRYPT_SALT` | bcrypt salt provided via application environment |
@@ -21,7 +23,7 @@ u3tl8gajo9paj0xki31jm1psr3v21m5urh50zoa7a262w4ntzoo6cqhu82
 
 API KEY generation algorithm:
 
-1. `TOKEN` := 130 bit random number and encode to base32
+1. `TOKEN` := 130 bit random number and encode to base32, optionally prefixed with a human readable string based on the token account type
 2. `CHECKSUM` := `hmacSha1(concat(TOKEN, TOKEN_API_HMAC_SECRET))`
 3. `API_KEY` := `concat(TOKEN, CHECKSUM)`
 4. `TOKEN_HASH` := `bcrypt(TOKEN, TOKEN_DB_BCRYPT_SALT)`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ govukpay_live_u3tl8gajo9paj0xki31jm1psr3v21m5urh50zoa7a262w4ntzoo6cqhu82
 ```
 
 | Item | Definition |
-|------|------------|"
+|------|------------|
 | `TOKEN` | randomly generated base 32 string, 130 bits entropy, variable length, optionally includes a human readable prefix |
 | `CHECKSUM` | `hmacSha1(TOKEN + TOKEN_API_HMAC_SECRET)`, base32 encoded. Always 32 characters long |
 | `TOKEN_API_HMAC_SECRET` | secret provided via application environment |

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Payments Public API Authentication Service
 Anatomy of an api key:
 
 ```
-govukpay_live_u3tl8gajo9paj0xki31jm1psr3v21m5urh50zoa7a262w4ntzoo6cqhu82
-`------------`'------------------------------'
-   PREFIX           RANDOM BASE32 STRING
+api_live_u3tl8gajo9paj0xki31jm1psr3v21m5urh50zoa7a262w4ntzoo6cqhu82
+`-------`'-----------------------------------'
+ PREFIX           RANDOM BASE32 STRING
 `--------------------------------------------'`------------------------'
                    TOKEN                        CHECKSUM
 ```

--- a/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
@@ -35,8 +35,8 @@ public class TokenService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TokenService.class);
 
-    private static final String PREFIX_TEST = "govukpay_test_";
-    private static final String PREFIX_LIVE = "govukpay_live_";
+    private static final String PREFIX_TEST = "api_test_";
+    private static final String PREFIX_LIVE = "api_live_";
 
     private static final int HMAC_SHA1_LENGTH = 32;
     private static final int PREFIX_MAX_LENGTH = Math.max(PREFIX_LIVE.length(), PREFIX_TEST.length());

--- a/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
@@ -20,6 +20,7 @@ import uk.gov.pay.publicauth.model.TokenResponse;
 import uk.gov.pay.publicauth.model.TokenSource;
 import uk.gov.pay.publicauth.model.TokenState;
 import uk.gov.pay.publicauth.model.Tokens;
+import uk.gov.pay.publicauth.model.TokenAccountType;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -34,9 +35,13 @@ public class TokenService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TokenService.class);
 
+    private static final String PREFIX_TEST = "govukpay_test_";
+    private static final String PREFIX_LIVE = "govukpay_live_";
+
     private static final int HMAC_SHA1_LENGTH = 32;
+    private static final int PREFIX_MAX_LENGTH = Math.max(PREFIX_LIVE.length(), PREFIX_TEST.length());
     private static final int API_KEY_MIN_LENGTH = HMAC_SHA1_LENGTH + RANDOM_ID_MIN_LENGTH;
-    private static final int API_KEY_MAX_LENGTH = HMAC_SHA1_LENGTH + RANDOM_ID_MAX_LENGTH;
+    private static final int API_KEY_MAX_LENGTH = PREFIX_MAX_LENGTH + HMAC_SHA1_LENGTH + RANDOM_ID_MAX_LENGTH;
 
     private final String encryptDBSalt;
     private final String apiKeyHmacSecret;
@@ -49,7 +54,7 @@ public class TokenService {
     }
 
     public String createTokenForAccount(CreateTokenRequest createTokenRequest) {
-        Tokens tokens = issueTokens();
+        Tokens tokens = issueTokens(createTokenRequest);
         authTokenDao.storeToken(tokens.getHashedToken(), createTokenRequest);
         LOGGER.info("Created token with token_link {}", createTokenRequest.getTokenLink());
         return tokens.getApiKey();
@@ -120,8 +125,9 @@ public class TokenService {
      * - Salted BCrypt Hash. Intended to be used as encrypted value when storing in DB
      * - Token + Hmac(Token + SecretKey). To be used as API key
      */
-    private Tokens issueTokens() {
-        final String newId = newId();
+    private Tokens issueTokens(CreateTokenRequest createTokenRequest) {
+        final String prefix = generateTokenPrefix(createTokenRequest);
+        final String newId = prefix + newId();
         return new Tokens(encrypt(newId), createApiKey(newId));
     }
     
@@ -147,5 +153,18 @@ public class TokenService {
         int apiKeyLength = apiKey.length();
         return (apiKeyLength >= API_KEY_MIN_LENGTH)
                 && (apiKeyLength <= API_KEY_MAX_LENGTH);
+    }
+
+    private String generateTokenPrefix(CreateTokenRequest createTokenRequest) {
+        TokenAccountType tokenAccountType = createTokenRequest.getTokenAccountType();
+        if (tokenAccountType != null) {
+            if (tokenAccountType == TokenAccountType.LIVE) {
+                return PREFIX_LIVE;
+            }
+            if (tokenAccountType == TokenAccountType.TEST) {
+                return PREFIX_TEST;
+            }
+        }
+        return "";
     }
 }

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
@@ -157,7 +157,7 @@ public class PublicAuthResourceIT {
                 .statusCode(200)
                 .body("token", is(notNullValue()))
                 .extract().path("token");
-        assertThat(newToken.contains("govukpay_test_"), is(true));
+        assertThat(newToken.contains("api_test_"), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
@@ -61,7 +61,6 @@ public class PublicAuthResourceIT {
     private static final String ACCOUNT_ID_2 = "ACCOUNT-ID-2";
     private static final String TOKEN_DESCRIPTION = "TOKEN DESCRIPTION";
     private static final String TOKEN_DESCRIPTION_2 = "Token description 2";
-    private static final String TOKEN_ACCOUNT_TYPE = "live";
     private static final String USER_EMAIL = "user@email.com";
     private static final String TOKEN_HASH_COLUMN = "token_hash";
     private static final String CREATED_USER_NAME = "user-name";
@@ -72,6 +71,7 @@ public class PublicAuthResourceIT {
     private final String validTokenPayload = new Gson().toJson(
             ImmutableMap.of("account_id", ACCOUNT_ID,
                     "description", TOKEN_DESCRIPTION,
+                    "token_account_type", "live",
                     "created_by", USER_EMAIL));
     private final String validDirectDebitTokenPayload = new Gson().toJson(
             ImmutableMap.of("account_id", ACCOUNT_ID,
@@ -85,7 +85,7 @@ public class PublicAuthResourceIT {
                     "created_by", USER_EMAIL));
     private final String validTokenPayloadWithTokenAccountType = new Gson().toJson(
             ImmutableMap.of("account_id", ACCOUNT_ID,
-                    "token_account_type", "LIVE",
+                    "token_account_type", "test",
                     "description", TOKEN_DESCRIPTION,
                     "created_by", USER_EMAIL));
 
@@ -157,6 +157,7 @@ public class PublicAuthResourceIT {
                 .statusCode(200)
                 .body("token", is(notNullValue()))
                 .extract().path("token");
+        assertThat(newToken.contains("govukpay_test_"), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
@@ -111,6 +111,8 @@ public class TokenServiceTest {
         // Minimum length guarantee is 32 for Hmac and an extremely very unlikely
         // minimum value of 1 length for the random Token this value is more likely to be 24~26 chars length
         assertThat(apiKey.length(), is(greaterThan(33)));
+
+        // this additionally asserts that no prefix is added if no token account type is provided (as the prefix includes the _ character)
         assertThat(BASE32_HEX_DICTIONARY.containsAll(asList(apiKey.toCharArray())), is(true));
 
         verify(mockAuthTokenDao).storeToken(tokenHashArgumentCaptor.capture(), eq(createTokenRequest));
@@ -131,6 +133,20 @@ public class TokenServiceTest {
         // check Hmac matches token
         String hmacFromExtractedPlainToken = BaseEncoding.base32Hex().omitPadding().lowerCase().encode(new HmacUtils(HmacAlgorithms.HMAC_SHA_1, EXPECTED_SECRET_KEY).hmac(plainToken));
         assertThat(hmacFromExtractedPlainToken, is(hmacApiKey));
+    }
+
+    @Test
+    public void shouldCreateValidToken_withPrefixForLiveAccountType() {
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.LIVE);
+        String apiKey = tokenService.createTokenForAccount(createTokenRequest);
+        assertThat(apiKey.contains("govukpay_live_"), is(true));
+    }
+
+    @Test
+    public void shouldCreateValidToken_withPrefixForTestAccountType() {
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.TEST);
+        String apiKey = tokenService.createTokenForAccount(createTokenRequest);
+        assertThat(apiKey.contains("govukpay_test_"), is(true));
     }
 
     @Test
@@ -167,7 +183,7 @@ public class TokenServiceTest {
     @Test
     public void extractEncryptedTokenFromApiKey_shouldNotBePresent_whenLengthIsGreaterThanExpected() {
 
-        String tokenGreaterThan26Characters = "morethan26chartokenisnotval";
+        String tokenGreaterThan26Characters = "morethan40chartokenisnotvalwiththatprefix";
         String hmac = BaseEncoding.base32Hex().omitPadding().lowerCase().encode(new HmacUtils(HmacAlgorithms.HMAC_SHA_1, EXPECTED_SECRET_KEY).hmac(tokenGreaterThan26Characters));
 
         Optional<Token> expectedValidTokenOptional = tokenService.extractEncryptedTokenFrom(tokenGreaterThan26Characters + hmac);

--- a/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
@@ -139,14 +139,14 @@ public class TokenServiceTest {
     public void shouldCreateValidToken_withPrefixForLiveAccountType() {
         CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.LIVE);
         String apiKey = tokenService.createTokenForAccount(createTokenRequest);
-        assertThat(apiKey.contains("govukpay_live_"), is(true));
+        assertThat(apiKey.contains("api_live_"), is(true));
     }
 
     @Test
     public void shouldCreateValidToken_withPrefixForTestAccountType() {
         CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.TEST);
         String apiKey = tokenService.createTokenForAccount(createTokenRequest);
-        assertThat(apiKey.contains("govukpay_test_"), is(true));
+        assertThat(apiKey.contains("api_test_"), is(true));
     }
 
     @Test
@@ -182,11 +182,10 @@ public class TokenServiceTest {
 
     @Test
     public void extractEncryptedTokenFromApiKey_shouldNotBePresent_whenLengthIsGreaterThanExpected() {
+        String tokenGreaterThan35Characters = "morethan35chartokenisnotvalincprefix";
+        String hmac = BaseEncoding.base32Hex().omitPadding().lowerCase().encode(new HmacUtils(HmacAlgorithms.HMAC_SHA_1, EXPECTED_SECRET_KEY).hmac(tokenGreaterThan35Characters));
 
-        String tokenGreaterThan26Characters = "morethan40chartokenisnotvalwiththatprefix";
-        String hmac = BaseEncoding.base32Hex().omitPadding().lowerCase().encode(new HmacUtils(HmacAlgorithms.HMAC_SHA_1, EXPECTED_SECRET_KEY).hmac(tokenGreaterThan26Characters));
-
-        Optional<Token> expectedValidTokenOptional = tokenService.extractEncryptedTokenFrom(tokenGreaterThan26Characters + hmac);
+        Optional<Token> expectedValidTokenOptional = tokenService.extractEncryptedTokenFrom(tokenGreaterThan35Characters + hmac);
         assertThat(expectedValidTokenOptional.isPresent(), is(false));
     }
 


### PR DESCRIPTION
IFF an account type is provided in the create api key request, attach a
prefix part to the api key token. This prefix is then included in the
hash/ checksum.

## How to test
API key authentication is called on almost every interaction with Pay, as this is a significant change to this code it should verified in test and staging environments against historic and new data before being released to production. 

In all environments:
- API key authentication works for existing API tokens without token prefix
- If an account type is provided on creating an API key, the appropriate prefix is included in the generated token
- If no account type is provided, no prefix is included
- API key authentication works with new API keys with prefixed token
