### PR TITLE
BAU — Use yyyy (year) instead of YYYY (week year) when formatting

### DIFF
--- a/src/main/java/uk/gov/pay/publicauth/json/DateTimeStringSerializer.java
+++ b/src/main/java/uk/gov/pay/publicauth/json/DateTimeStringSerializer.java
@@ -20,6 +20,6 @@ public class DateTimeStringSerializer extends StdSerializer<ZonedDateTime> {
     
     @Override
     public void serialize(ZonedDateTime zonedDateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-        jsonGenerator.writeString(DateTimeFormatter.ofPattern("dd MMM YYYY - HH:mm").format(zonedDateTime));
+        jsonGenerator.writeString(DateTimeFormatter.ofPattern("dd MMM yyyy - HH:mm").format(zonedDateTime));
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -53,7 +53,7 @@ public class PublicAuthResource {
     private static final String TOKEN_LINK_FIELD = "token_link";
     private static final String TOKEN_FIELD = "token";
     private static final String DESCRIPTION_FIELD = "description";
-    private static final String REVOKED_DATE_FORMAT_PATTERN = "dd MMM YYYY";
+    private static final String REVOKED_DATE_FORMAT_PATTERN = "dd MMM yyyy";
     
     private final TokenService tokenService;
 

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
@@ -47,7 +47,7 @@ import static uk.gov.pay.publicauth.model.TokenSource.PRODUCTS;
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class PublicAuthResourceIT {
 
-    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd MMM YYYY - HH:mm");
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy - HH:mm");
 
     private static final String SALT = "$2a$10$IhaXo6LIBhKIWOiGpbtPOu";
     private static final String BEARER_TOKEN = "testbearertoken";
@@ -536,7 +536,7 @@ public class PublicAuthResourceIT {
 
         revokeSingleToken(ACCOUNT_ID, "{\"token_link\" : \"" + TOKEN_LINK.toString() + "\"}")
                 .statusCode(200)
-                .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
+                .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM yyyy"))));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
@@ -548,7 +548,7 @@ public class PublicAuthResourceIT {
         String fullBearerToken = BEARER_TOKEN + "qgs2ot3itqer7ag9mvvbs8snqb5jfas3";
         revokeSingleToken(ACCOUNT_ID, "{\"token\" : \"" + fullBearerToken + "\"}")
                 .statusCode(200)
-                .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM YYYY"))));
+                .body("revoked", is(ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("dd MMM yyyy"))));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));


### PR DESCRIPTION
Around the beginning or the end of the year, the week year (YYYY) is not always the same as what we usually think of as the year (yyyy).