### PR TITLE
PP-7922: Test DB migration for Concourse job

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -100,5 +100,13 @@
             UPDATE tokens SET type = 'API';
         </sql>
     </changeSet>
+
+    <changeSet id="create empty table to test concourse db migration" author="">
+        <createTable tableName="test_concourse_db_migration">
+            <column name="id" type="bigserial" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
     
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
We're moving DB migration jobs to Concourse. This PR adds a dummy table to test that the migration job works as expected. [See the equivalent PR for Connector](https://github.com/alphagov/pay-connector/pull/2930).

We'll remove the table again in a subsequent PR.

