### PR TITLE
PP-7922: DB migration to remove Concourse test table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -108,5 +108,9 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet id="remove empty table to test concourse db migration" author="">
+        <dropTable cascadeConstraints="true" tableName="test_concourse_db_migration" />
+    </changeSet>
     
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
Once we've tested the new Concourse DB migration job for publicauth, we can drop the test table again.

[See the equivalent Connector PR here](https://github.com/alphagov/pay-connector/pull/2933).



