### PR TITLE
[PP-8695] Kill ECS Deploy from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,14 +84,6 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
-     when {
-       branch 'master'
-     }
-     steps {
-       deployEcs("publicauth")
-     }
-   }
    stage('Smoke Tests') {
      when { branch 'master' }
      steps { runCardSmokeTest() }


### PR DESCRIPTION
## WHAT
This should stop our builds from failing.