### PR TITLE
PP-9010 Upgrade log4j-core and log4j-api to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,18 @@
         <junit5.version>5.8.2</junit5.version>
     </properties>
     <dependencies>
+        <!-- We do not use log4j-core or log4j-api but some dependencies do
+             and versions before 2.15.0 are vulnerable to CVE-2021-44228 -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.15.0</version>
+        </dependency>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging</artifactId>


### PR DESCRIPTION
Upgrade log4j-core and log4j-api (which we do not use but some dependencies do) to version 2.15.0 to fix CVE-2021-44228.