### PR TITLE
PP-9620 update liquibase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.3.3</version>
+            <version>4.12.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>


### PR DESCRIPTION
## WHAT

- The Github UI is giving critical warnings for our Java apps with liquibase below v4.8.0. Patched liquibase to 4.12.0
