### PR TITLE
PP-9620 update dependabot yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
   - dependencies
   - govuk-pay
   - java
-  ignore:
-  - dependency-name: org.liquibase:liquibase-core
-    versions:
-    - ">= 3.8.a"
-    - "< 3.9"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
## WHAT
- ignoring liquibase is no longer required, remove it from dependabot yaml file.
