### PR TITLE
PP-10004 M1 support for integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,6 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Pull docker image dependencies
         run: |
-          docker pull govukpay/postgres:11.1
+          docker pull postgres:11.16
       - name: Run unit and integration tests
         run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <jackson.version>2.13.4.2</jackson.version>
         <dropwizard.version>2.1.3</dropwizard.version>
         <guava.version>31.1-jre</guava.version>
-        <pay-java-commons.version>1.0.20221010091710</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20221018103433</pay-java-commons.version>
         <junit5.version>5.9.1</junit5.version>
         <swaggger-version>2.2.3</swaggger-version>
     </properties>
@@ -156,6 +156,18 @@
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>testing</artifactId>
             <version>${pay-java-commons.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.17.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.17.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -10,7 +10,7 @@ import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenSource;
 import uk.gov.pay.publicauth.model.TokenState;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -84,21 +84,21 @@ public class AuthTokenDao {
         }
     }
 
-    public Optional<ZonedDateTime> revokeSingleToken(String accountId, TokenHash tokenHash) {
+    public Optional<LocalDateTime> revokeSingleToken(String accountId, TokenHash tokenHash) {
         return Optional.ofNullable(jdbi.withHandle(handle ->
                 handle.createQuery("UPDATE tokens SET revoked=(now() at time zone 'utc') WHERE account_id=:account_id AND token_hash=:token_hash AND revoked IS NULL RETURNING revoked")
                         .bind("account_id", accountId)
                         .bind("token_hash", tokenHash.getValue())
-                        .mapTo(ZonedDateTime.class)
+                        .mapTo(LocalDateTime.class)
                         .first()));
     }
 
-    public Optional<ZonedDateTime> revokeSingleToken(String accountId, TokenLink tokenLink) {
+    public Optional<LocalDateTime> revokeSingleToken(String accountId, TokenLink tokenLink) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("UPDATE tokens SET revoked=(now() at time zone 'utc') WHERE account_id=:account_id AND token_link=:token_link AND revoked IS NULL RETURNING revoked")
                         .bind("account_id", accountId)
                         .bind("token_link", tokenLink.toString())
-                        .mapTo(ZonedDateTime.class)
+                        .mapTo(LocalDateTime.class)
                         .findFirst());
     }
 

--- a/src/main/java/uk/gov/pay/publicauth/dao/TokenMapper.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/TokenMapper.java
@@ -9,7 +9,8 @@ import uk.gov.pay.publicauth.model.TokenSource;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -37,9 +38,9 @@ public class TokenMapper implements RowMapper<TokenEntity> {
     }
 
     private Optional<ZonedDateTime> getZonedDateTime(ResultSet rs, String columnLabel) throws SQLException {
-        Timestamp timestamp = rs.getTimestamp(columnLabel);
+        LocalDateTime dateTime = rs.getObject(columnLabel, LocalDateTime.class);
 
-        return Optional.ofNullable(timestamp)
-                .map(t -> ZonedDateTime.ofInstant(t.toInstant(), ZoneOffset.UTC));
+        return Optional.ofNullable(dateTime)
+                .map(t -> ZonedDateTime.ofInstant(dateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC")));
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
@@ -113,12 +113,12 @@ public class TokenService {
     }
 
     public ZonedDateTime revokeToken(String accountId, TokenHash tokenHash) {
-        return authTokenDao.revokeSingleToken(accountId, tokenHash).map(localDateTime -> ZonedDateTime.ofInstant(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC")))
+        return authTokenDao.revokeSingleToken(accountId, tokenHash).map(localDateTime -> localDateTime.atZone(ZoneOffset.UTC))
                 .orElseThrow(() -> new TokenNotFoundException("Could not revoke token"));
     }
     
     public ZonedDateTime revokeToken(String accountId, TokenLink tokenLink) {
-        return authTokenDao.revokeSingleToken(accountId, tokenLink).map(localDateTime -> ZonedDateTime.ofInstant(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC")))
+        return authTokenDao.revokeSingleToken(accountId, tokenLink).map(localDateTime -> localDateTime.atZone(ZoneOffset.UTC))
                 .orElseThrow(() -> new TokenNotFoundException("Could not revoke token with token_link " + tokenLink));
     }
 

--- a/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
@@ -22,6 +22,8 @@ import uk.gov.pay.publicauth.model.TokenState;
 import uk.gov.pay.publicauth.model.Tokens;
 import uk.gov.pay.publicauth.model.TokenAccountType;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -111,12 +113,12 @@ public class TokenService {
     }
 
     public ZonedDateTime revokeToken(String accountId, TokenHash tokenHash) {
-        return authTokenDao.revokeSingleToken(accountId, tokenHash)
+        return authTokenDao.revokeSingleToken(accountId, tokenHash).map(localDateTime -> ZonedDateTime.ofInstant(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC")))
                 .orElseThrow(() -> new TokenNotFoundException("Could not revoke token"));
     }
     
     public ZonedDateTime revokeToken(String accountId, TokenLink tokenLink) {
-        return authTokenDao.revokeSingleToken(accountId, tokenLink)
+        return authTokenDao.revokeSingleToken(accountId, tokenLink).map(localDateTime -> ZonedDateTime.ofInstant(localDateTime.toInstant(ZoneOffset.UTC), ZoneId.of("UTC")))
                 .orElseThrow(() -> new TokenNotFoundException("Could not revoke token with token_link " + tokenLink));
     }
 

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
@@ -260,7 +260,7 @@ public class AuthTokenDaoIT {
 
         Optional<LocalDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
 
-        var actual = ZonedDateTime.ofInstant(revokedDate.get().toInstant(ZoneOffset.UTC), ZoneId.of("UTC"));
+        var actual = revokedDate.get().atZone(UTC);
 
         assertThat(actual, isCloseTo(ZonedDateTime.now(UTC)));
 
@@ -273,8 +273,8 @@ public class AuthTokenDaoIT {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
         Optional<LocalDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_HASH);
-        
-        var actual = ZonedDateTime.ofInstant(revokedDate.get().toInstant(ZoneOffset.UTC), ZoneId.of("UTC"));
+
+        var actual = revokedDate.get().atZone(UTC);
         
         assertThat(actual, isCloseTo(ZonedDateTime.now(UTC)));
 

--- a/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/dao/AuthTokenDaoIT.java
@@ -13,6 +13,10 @@ import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenAccountType;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresRule;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.util.List;
@@ -254,9 +258,11 @@ public class AuthTokenDaoIT {
     public void shouldRevokeASingleTokenByTokenLink() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
-        Optional<ZonedDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
+        Optional<LocalDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
 
-        assertThat(revokedDate.get(), isCloseTo(ZonedDateTime.now(UTC)));
+        var actual = ZonedDateTime.ofInstant(revokedDate.get().toInstant(ZoneOffset.UTC), ZoneId.of("UTC"));
+
+        assertThat(actual, isCloseTo(ZonedDateTime.now(UTC)));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
@@ -266,9 +272,11 @@ public class AuthTokenDaoIT {
     public void shouldRevokeASingleTokenByTokenHash() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
 
-        Optional<ZonedDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_HASH);
-
-        assertThat(revokedDate.get(), isCloseTo(ZonedDateTime.now(UTC)));
+        Optional<LocalDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_HASH);
+        
+        var actual = ZonedDateTime.ofInstant(revokedDate.get().toInstant(ZoneOffset.UTC), ZoneId.of("UTC"));
+        
+        assertThat(actual, isCloseTo(ZonedDateTime.now(UTC)));
 
         Optional<String> revokedInDb = app.getDatabaseHelper().lookupColumnForTokenTable("revoked", "token_link", TOKEN_LINK.toString());
         assertThat(revokedInDb.isPresent(), is(true));
@@ -279,7 +287,7 @@ public class AuthTokenDaoIT {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, TEST_USER_NAME);
         app.getDatabaseHelper().insertAccount(TOKEN_HASH_2, TOKEN_LINK_2, ACCOUNT_ID_2, TOKEN_DESCRIPTION_2, TEST_USER_NAME);
 
-        Optional<ZonedDateTime> revokedDate  = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK_2);
+        Optional<LocalDateTime> revokedDate  = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK_2);
 
         assertThat(revokedDate.isPresent(), is(false));
 
@@ -291,7 +299,7 @@ public class AuthTokenDaoIT {
     public void shouldNotRevokeATokenAlreadyRevoked() {
         app.getDatabaseHelper().insertAccount(TOKEN_HASH, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION,  ZonedDateTime.now(UTC), TEST_USER_NAME);
 
-        Optional<ZonedDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
+        Optional<LocalDateTime> revokedDate = authTokenDao.revokeSingleToken(ACCOUNT_ID, TOKEN_LINK);
 
         assertThat(revokedDate.isPresent(), is(false));
 

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -6,6 +6,8 @@ import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenPaymentType;
 import uk.gov.pay.publicauth.model.TokenSource;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
@@ -80,15 +82,17 @@ public class DatabaseTestHelper {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT " + column + " FROM tokens WHERE account_id=:accountId")
                         .bind("accountId", accountId)
-                        .mapTo(ZonedDateTime.class)
-                        .first());
+                        .mapTo(LocalDateTime.class)
+                        .first())
+                        .atZone(ZoneId.of("UTC"));
     }
 
     public ZonedDateTime getCurrentTime() {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT (now() at time zone 'utc')")
-                        .mapTo(ZonedDateTime.class)
+                        .mapTo(LocalDateTime.class)
                         .first())
-                        .withZoneSameInstant(UTC);
+                        .atZone(ZoneId.of("UTC"));
+                        
     }
 }

--- a/src/test/java/uk/gov/pay/publicauth/utils/PostgresTestContainersBase.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/PostgresTestContainersBase.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.publicauth.utils;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static java.lang.String.format;
+
+public abstract class PostgresTestContainersBase {
+
+    public final static String VERSION = "11.16";
+    public static final PostgreSQLContainer POSTGRES_CONTAINER;
+    
+    static {
+        POSTGRES_CONTAINER = new PostgreSQLContainer(format("postgres:%s", VERSION)).withUsername("postgres").withPassword("mysecretpassword");
+        POSTGRES_CONTAINER.start();
+    }
+}

--- a/src/test/resources/it-migrations.xml
+++ b/src/test/resources/it-migrations.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="install necessary extensions for integration tests" author="">
+        <sql>
+            CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+            CREATE EXTENSION IF NOT EXISTS "pg_trgm" WITH SCHEMA "pg_catalog";
+            ALTER DATABASE postgres SET timezone TO "UTC";
+        </sql>
+    </changeSet>
+
+    <include file="migrations.xml" relativeToChangelogFile="false"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
## WHAT

- fixed some timeywimey bugs:
  - stopped mapping JDBC query responses to ZonedDateTime as Postgres is not storing timezone information and this was leading to some odd behaviour in tests when deserialising
   - removed use of `java.sql.Timestamp` in TokenMapper due to confusing behaviour when converting to and from Instant
- removed use of `govuk/postgres:11`, baselining on architecture agnostic `postgres:11.16`
- updated test bases and rules to enable cross architecture support
- added integration tests specific liquibase changelog (`it-migrations.xml`) to initialise the database before migrations can be run
- updated GHA to use new postgres image
- added testcontainers to better handle the health check integration test
