### PR TITLE
PP-10255 Check if there are uncommitted changes to OpenApi file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,5 +28,13 @@ jobs:
       - name: Pull docker image dependencies
         run: |
           docker pull postgres:11.16
+      - name: Compile
+        run: mvn clean compile
+      - name: Check for OpenApi file changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo "Changes to the OpenApi file have not been committed. Run \`mvn compile\` on your branch to regenerate the file and then commit the changes."
+            exit 1
+          fi
       - name: Run unit and integration tests
-        run: mvn clean verify
+        run: mvn verify

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # pay-publicauth
 Payments Public API Authentication Service
 
+## API Specification
+
+The [API Specification](openapi/publicauth_spec.yaml) provides more detail on the paths and operations including examples.
+
+[View the API specification for publicauth in Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/alphagov/pay-publicauth/master/openapi/publicauth_spec.yaml).
+
 ## API Keys
 
 Anatomy of an api key:
@@ -72,10 +78,6 @@ The command to run the integration tests is:
 ```
     mvn test
 ```
-
-## API Specification
-
-The [API Specification](openapi/publicauth_spec.yaml) provides more detail on the paths and operations including examples.
 
 ## Licence
 


### PR DESCRIPTION
Add a check in the GitHub actions workflow that runs on PR builds to check whether there are uncommitted changes after running `mvn compile`. If there are, this suggests that there have been changes to the API specification and the OpenApi file has not been regenerated. Fail the build when uncommitted changes are detected.
