### PR TITLE
PP-7607 Remove explicit liquibase dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,23 +44,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-migrations</artifactId>
             <version>${dropwizard.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.liquibase</groupId>
-                    <artifactId>liquibase-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
-            <version>4.17.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>jstl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
We initially included an explicit liquibase dependency because 3.4.* versions of liquibase were throwing warnings when running our migrations. We downgraded to version 3.3.5 of liquibase to prevent this.

Use the version of liquibase that `dropwizard-migrations` depends on instead of specifying the version ourselves to avoid incompatibilities.


