### PR TITLE
PP-10116 update secrets baseline, pre-commit conf

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
+
   integration-tests:
     name: Unit and Integration tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 repos:
-- repo: https://github.com/Yelp/detect-secrets
-  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
-  hooks:
-    - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
-      exclude: package.lock.json
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "version": "1.1.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -18,8 +21,14 @@
       "name": "CloudantDetector"
     },
     {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,13 +47,22 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -56,10 +74,6 @@
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -94,31 +108,22 @@
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
+    "openapi/publicauth_spec.yaml": [
       {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "type": "Base64 High Entropy String",
+        "filename": "openapi/publicauth_spec.yaml",
+        "hashed_secret": "504fdcd9f2dc1213b2f032a7ca2bba4a659ea27a",
         "is_verified": false,
-        "line_number": 3
+        "line_number": 62
       }
     ],
-    "dev.yml": [
+    "src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java": [
       {
-        "type": "Secret Keyword",
-        "filename": "dev.yml",
-        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "type": "Base64 High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java",
+        "hashed_secret": "29f553afc34a3dc4ca28b995e11e244f0c47dfda",
         "is_verified": false,
-        "line_number": 2,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dev.yml",
-        "hashed_secret": "1af17e73721dbe0c40011b82ed4bb1a7dbe3ce29",
-        "is_verified": false,
-        "line_number": 11,
-        "is_secret": false
+        "line_number": 100
       }
     ],
     "src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java": [
@@ -136,18 +141,16 @@
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_verified": false,
-        "line_number": 24,
-        "is_secret": false
+        "line_number": 24
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 55,
-        "is_secret": false
+        "line_number": 55
       }
     ]
   },
-  "generated_at": "2021-08-13T15:25:56Z"
+  "generated_at": "2022-11-08T17:43:16Z"
 }


### PR DESCRIPTION
### WHAT

- added a new github action to run `detect-secrets`
- updated the pre-commit config to update the detect-secrets hook to version `1.4`
- rebaselined the repository's secrets baseline

#### For reviewers

- ensure your local version of `detect-secrets` matches the latest version in use on this branch
- run `detect-secrets scan` and ensure output matches the latest `.secrets.baseline`, the only change should be the generated timestamp