### PR TITLE
BAU: Pin base images to Java v11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+  - dependency-name: "eclipse-temurin"
+    versions:
+    - "> 11"
   open-pull-requests-limit: 10
   labels:
   - dependencies
@@ -25,6 +29,10 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  ignore:
+  - dependency-name: "eclipse-temurin"
+    versions:
+    - "> 11"
   open-pull-requests-limit: 10
   labels:
   - dependencies


### PR DESCRIPTION
## WHAT
Dependabot is keen to update to `eclipse-temurin:20-jre` - we're happy with `11-jre` for the moment.

