### PR TITLE
PP-11228: Remove graphite metrics sending and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ API KEY validation algorithm:
 | `DB_USER`               | The username to log into the database as. |
 | `JAVA_HOME`             | The location of the JRE. Set to `/opt/java/openjdk` in the `Dockerfile`. |
 | `JAVA_OPTS`             | Commandline arguments to pass to the java runtime. Optional. |
-| `METRICS_HOST`          | The hostname to send graphite metrics to. Defaults to `localhost`. |
-| `METRICS_PORT`          | The port number to send graphite metrics to. Defaults to `8092`. |
 | `PORT`                  | The port number to listen for requests on. Defaults to `8080`. |
 | `RUN_APP`               | Set to `true` to run the application. Defaults to `true`. |
 | `RUN_MIGRATION`         | Set to `true` to run a database migration. Defaults to `false`. |

--- a/pom.xml
+++ b/pom.xml
@@ -96,10 +96,6 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-graphite</artifactId>
-        </dependency>
-        <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>utils</artifactId>
             <version>${pay-java-commons.version}</version>

--- a/src/main/java/uk/gov/pay/publicauth/app/config/PublicAuthConfiguration.java
+++ b/src/main/java/uk/gov/pay/publicauth/app/config/PublicAuthConfiguration.java
@@ -22,12 +22,6 @@ public class PublicAuthConfiguration extends Configuration {
     @JsonProperty("tokensConfig")
     private TokensConfiguration TokensConfiguration;
 
-    @NotNull
-    private String graphiteHost;
-
-    @NotNull
-    private Integer graphitePort;
-
     @JsonProperty("ecsContainerMetadataUriV4")
     private URI ecsContainerMetadataUriV4;
 
@@ -37,14 +31,6 @@ public class PublicAuthConfiguration extends Configuration {
 
     public TokensConfiguration getTokensConfiguration() {
         return TokensConfiguration;
-    }
-
-    public String getGraphiteHost() {
-        return graphiteHost;
-    }
-
-    public Integer getGraphitePort() {
-        return graphitePort;
     }
 
     public Optional<URI> getEcsContainerMetadataUriV4() {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -68,7 +68,4 @@ tokensConfig:
   encryptDBSalt: ${TOKEN_DB_BCRYPT_SALT}
   apiKeyHmacSecret: ${TOKEN_API_HMAC_SECRET}
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -58,7 +58,4 @@ tokensConfig:
   encryptDBSalt: $2a$10$IhaXo6LIBhKIWOiGpbtPOu
   apiKeyHmacSecret: qwer9yuhgf
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}


### PR DESCRIPTION
## WHAT
1. Remove graphite metrics configuration and sending
2. Rename GRAPHITE_SENDING_PERIOD_SECONDS to METRICS_COLLECTION_PERIOD_SECONDS, and set it to the appropriate value.

## HOW 
Check build passes and explicitly allow e2e tests to complete
