### PR TITLE
PP-11154: Update initialise prometheus metrics

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -5,4 +5,8 @@ set -e
 cd "$(dirname "$0")"
 
 mvn -DskipITs clean verify
-docker build -t govukpay/publicauth:local .
+if [ "$(uname -m)" == "arm64" ]; then
+  docker build -t governmentdigitalservice/pay-publicauth:local -f m1/arm64.Dockerfile .
+else
+  docker build -t governmentdigitalservice/pay-publicauth:local .
+fi

--- a/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
+++ b/src/main/java/uk/gov/pay/publicauth/app/PublicAuthApp.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 import uk.gov.service.payments.commons.utils.metrics.DatabaseMetricsService;
-import uk.gov.service.payments.commons.utils.prometheus.PrometheusDefaultLabelSampleBuilder;
 import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
 import uk.gov.service.payments.logging.LoggingFilter;
 import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
@@ -40,7 +39,6 @@ import uk.gov.pay.publicauth.service.TokenService;
 import uk.gov.pay.publicauth.util.DependentResourceWaitCommand;
 import uk.gov.service.payments.logging.SentryAppenderFactory;
 
-import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -118,13 +116,8 @@ public class PublicAuthApp extends Application<PublicAuthConfiguration> {
                 .build()
                 .scheduleAtFixedRate(metricsService::updateMetricData, 0, METRICS_COLLECTION_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
 
-        configuration.getEcsContainerMetadataUriV4().ifPresent(uri -> initialisePrometheusMetrics(environment, uri));
-    }
-
-    private void initialisePrometheusMetrics(Environment environment, URI ecsContainerMetadataUri) {
-        LOGGER.info("Initialising prometheus metrics.");
-        CollectorRegistry collectorRegistry = new CollectorRegistry();
-        collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(ecsContainerMetadataUri)));
+        CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
+        collectorRegistry.register(new DropwizardExports(environment.metrics()));
         environment.admin().addServlet("prometheusMetrics", new MetricsServlet(collectorRegistry)).addMapping("/metrics");
     }
 


### PR DESCRIPTION
## WHAT YOU DID
Now we don't need to build our default labels in the app (since they are now added by the sidecar) we should remove the default sample builder.

1. Remove default sample builder
2. Update local build script to account for m1 macs, and use the correct container tag

## How to test

This change has already been rolled out to connector and is working well.


