### PR TITLE
BAU — Tell Dependabot to ignore Dropwizard Sentry 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       time: "03:00"
     ignore:
       - dependency-name: "io.dropwizard:dropwizard-dependencies"
+        # Dropwizard 4.x only works with Jakarta EE and not Java EE
+        versions:
+          - ">= 4"
+      - dependency-name: "org.dhatim:dropwizard-sentry"
+        # We essentially forked Dropwizard Sentry because it did not support
+        # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports
+        # Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work
+        # to go back to using an unmodified version
         versions:
           - ">= 4"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Tell Dependabot to ignore Dropwizard Sentry 4.x because it’s not going to be a just-merge-the-Dependabot-PR upgrade.

We essentially forked Dropwizard Sentry because it did not support Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work to go back to using an unmodified version.

Also add comments explaining why we’re ignoring upgrades for certain Maven dependencies.