### PR TITLE
PP-12728 Replace symlink with actual file for m1 build

### DIFF
--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,1 +1,38 @@
-../Dockerfile
+FROM maven:3.9.7-eclipse-temurin-21-alpine@sha256:8b762a139e07e874e3830521d97bafaf963cce6bda92afe9fb532def5d011404 AS builder
+
+WORKDIR /home/build
+COPY . .
+
+RUN ["mvn", "clean", "--no-transfer-progress", "package", "-DskipTests"]
+
+FROM eclipse-temurin:21-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67 AS final
+
+RUN ["apk", "--no-cache", "upgrade"]
+
+ARG DNS_TTL=15
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.security"
+
+COPY ./import_aws_rds_cert_bundles.sh /
+RUN /import_aws_rds_cert_bundles.sh && rm /import_aws_rds_cert_bundles.sh
+
+RUN ["apk", "add", "--no-cache", "bash", "tini"]
+
+ENV PORT 8080
+ENV ADMIN_PORT 8081
+
+EXPOSE 8080
+EXPOSE 8081
+
+WORKDIR /app
+
+COPY --from=builder /home/build/docker-startup.sh .
+COPY --from=builder /home/build/target/*.yaml .
+COPY --from=builder /home/build/target/pay-*-allinone.jar .
+
+ENTRYPOINT ["tini", "-e", "143", "--"]
+
+CMD ["bash", "./docker-startup.sh"]


### PR DESCRIPTION
## WHAT
- Replaces symlink for m1 docker file as code build can't build with symlinks

```

#1 [internal] load build definition from arm64.Dockerfile
--
94 | ERROR: failed to solve: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount2730447583/Dockerfile: no such file or directory

```