### PR TITLE
PP-13026: Add stored procedure to allow safer manual sql execution

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -112,5 +112,40 @@
     <changeSet id="remove empty table to test concourse db migration" author="">
         <dropTable cascadeConstraints="true" tableName="test_concourse_db_migration" />
     </changeSet>
-    
+
+    <changeSet id="create procedure to run adhoc DML statements" author="">
+        <createProcedure dbms="postgresql" procedureName="check_and_execute" >
+            Create or replace procedure check_and_execute(
+                p_dml_sql text,
+                p_table_name text,
+                p_expected_no_of_rows_to_update_or_delete numeric
+            )
+            Language plpgsql
+            As $$ declare
+                rows_affected INTEGER;
+                total_rows INTEGER;
+            Begin
+                EXECUTE format('SELECT COUNT(*) FROM %I', p_table_name) INTO total_rows;
+
+                if p_expected_no_of_rows_to_update_or_delete >= total_rows then
+                    raise exception 'Failed. Expected no. of rows (%) to update/delete can not be same or more than the total number of rows (%) in the table',
+                        p_expected_no_of_rows_to_update_or_delete,
+                        total_rows;
+                end if;
+
+                execute p_dml_sql;
+                get diagnostics rows_affected = ROW_COUNT;
+
+                if rows_affected != p_expected_no_of_rows_to_update_or_delete then
+                    raise exception 'Failed. Statement expected to update/delete % rows but updating % rows. Changes not commited.',
+                        p_expected_no_of_rows_to_update_or_delete,
+                        rows_affected;
+                end if;
+
+                raise notice 'Success. Statement affected % rows. Expected to update/delete LESS THAN or EQUAL to % rows',
+                    rows_affected,
+                    p_expected_no_of_rows_to_update_or_delete;
+            End; $$
+        </createProcedure>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
Add stored procedure check_and_execute which allows specifying SQL, the table, and expected number of rows affected. This should allow ad-hoc modifications to be done more safely since it will automatically error if the number of rows affected wasn't exactly what you had intended

This is based on the prior art in https://github.com/alphagov/pay-connector/pull/5451/ and the RFC https://github.com/alphagov/pay-architecture/discussions/147

## How to test

- Locally run up pay local with this branch of connector `pay local up --cluster card --local publicauth`
- Once it's running run `docker exec -it publicauth_db psql -U publicauth`
- List the functions `\df` you'll see check_and_execute exists.
- Try out the stored proc:
```
publicauth=> CALL check_and_execute('DELETE FROM databasechangelog', 'databasechangelog', 100000);
ERROR:  Failed. Expected no. of rows (100000) to update/delete can not be same or more than the total number of rows (10) in the table
CONTEXT:  PL/pgSQL function check_and_execute(text,text,numeric) line 8 at RAISE
publicauth=> BEGIN;
BEGIN
publicauth=*> CALL check_and_execute($$DELETE FROM databasechangelog WHERE id='build token table'$$, 'databasechangelog', 5);
ERROR:  Failed. Statement expected to update/delete 5 rows but updating 1 rows. Changes not commited.
CONTEXT:  PL/pgSQL function check_and_execute(text,text,numeric) line 17 at RAISE
publicauth=!> ROLLBACK;
ROLLBACK
publicauth=> BEGIN;
BEGIN
publicauth=*> CALL check_and_execute($$DELETE FROM databasechangelog WHERE id='build token table'$$, 'databasechangelog', 1);
NOTICE:  Success. Statement affected 1 rows. Expected to update/delete LESS THAN or EQUAL to 1 rows
CALL
publicauth=*> ROLLBACK;
ROLLBACK
```

## Code review checklist

### Logging

N/A

### Documentation

N/A