### PR TITLE
PP-12687: Add Dependency Review workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,3 +9,7 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/_run-tests.yml
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/pay-ci/.github/workflows/_run-dependency-review.yml@master


### PR DESCRIPTION
## WHAT
Adds the new [dependency review workflow](https://github.com/alphagov/pay-ci/pull/1329) to pre-merge checks.

