### PR TITLE
PP-12395: Get token by token link and account id

### DIFF
--- a/openapi/publicauth_spec.yaml
+++ b/openapi/publicauth_spec.yaml
@@ -183,6 +183,34 @@ paths:
         \ method currently does not return a 404."
       tags:
       - Auth
+  /v1/frontend/auth/{accountId}/{tokenLink}:
+    get:
+      operationId: getTokenByTokenLink
+      parameters:
+      - example: 1
+        in: path
+        name: accountId
+        required: true
+        schema:
+          type: string
+      - example: a-token-link
+        in: path
+        name: tokenLink
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+          description: OK
+        "404":
+          description: Token not found
+      summary: Get a token by gateway account id and token link.
+      tags:
+      - Auth
 components:
   schemas:
     AuthResponse:

--- a/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
+++ b/src/main/java/uk/gov/pay/publicauth/dao/AuthTokenDao.java
@@ -42,6 +42,17 @@ public class AuthTokenDao {
                         .bind("token_hash", tokenHash.getValue())
                         .execute());
     }
+    
+    public Optional<TokenEntity> findTokenBy(String accountId, TokenLink tokenLink) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery(TOKEN_SELECT +
+                                "WHERE account_id = :account_id " +
+                                "AND token_link = :token_link")
+                        .bind("account_id", accountId)
+                        .bind("token_link", tokenLink.toString())
+                        .map(new TokenMapper())
+                        .findFirst());
+    }
 
     public List<TokenEntity> findTokensBy(String accountId, TokenState tokenState, TokenSource tokenSource) {
         String revokedClause = (tokenState.equals(TokenState.REVOKED)) ? "AND revoked IS NOT NULL " : "AND revoked IS NULL ";

--- a/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
+++ b/src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java
@@ -145,6 +145,23 @@ public class PublicAuthResource {
         return ok(Map.of("tokens", tokenResponses)).build();
     }
 
+    @Path("/v1/frontend/auth/{accountId}/{tokenLink}")
+    @Timed
+    @Produces(APPLICATION_JSON)
+    @GET
+    @Operation(
+            summary = "Get a token by gateway account id and token link.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Token not found")
+            }
+    )
+    public Response getTokenByTokenLink(@Parameter(example = "1") @PathParam("accountId") String accountId,
+                                        @Parameter(example = "a-token-link") @PathParam("tokenLink") String tokenLink) {
+        return Response.ok(tokenService.findTokenBy(accountId, TokenLink.of(tokenLink))).build();    
+    }
+    
     @Path("/v1/frontend/auth")
     @Timed
     @Consumes(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
+++ b/src/main/java/uk/gov/pay/publicauth/service/TokenService.java
@@ -14,6 +14,7 @@ import uk.gov.pay.publicauth.exception.TokenNotFoundException;
 import uk.gov.pay.publicauth.exception.TokenRevokedException;
 import uk.gov.pay.publicauth.model.AuthResponse;
 import uk.gov.pay.publicauth.model.CreateTokenRequest;
+import uk.gov.pay.publicauth.model.TokenEntity;
 import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenResponse;
@@ -72,6 +73,11 @@ public class TokenService {
                     return new AuthResponse(tokenEntity.getAccountId(), tokenEntity.getTokenLink(), tokenEntity.getTokenPaymentType());
                 })
                 .orElseThrow(() -> new TokenInvalidException("Token does not exist"));
+    }
+    
+    public TokenResponse findTokenBy(String accountId, TokenLink tokenLink) {
+        return authTokenDao.findTokenBy(accountId, tokenLink).map(TokenResponse::fromEntity)
+                .orElseThrow(() -> new TokenNotFoundException("Could not update description of token with token_link " + tokenLink));
     }
 
     /**

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthResourceIT.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.DIRECT_DEBIT;
@@ -312,6 +313,31 @@ class PublicAuthResourceIT {
             getTokensFor(ACCOUNT_ID)
                     .statusCode(200)
                     .body("tokens", hasSize(0));
+        }
+        
+        @Test
+        void get_token_by_tokenLink_should_return_200_if_token_exists() {
+            databaseHelper.insertAccount(HASHED_BEARER_TOKEN, TOKEN_LINK, ACCOUNT_ID, TOKEN_DESCRIPTION, null, CREATED_USER_NAME, null);
+
+            given().port(localPort)
+                    .accept(JSON)
+                    .get(String.format("/v1/frontend/auth/%s/%s", ACCOUNT_ID, TOKEN_LINK))
+                    .then()
+                    .statusCode(200)
+                    .body("token_link", is(TOKEN_LINK.toString()))
+                    .body("description", is(TOKEN_DESCRIPTION))
+                    .body("last_used", nullValue())
+                    .body("created_by", is(CREATED_USER_NAME))
+                    .body("token_type", is(CARD.toString()));
+        }
+
+        @Test
+        void get_token_by_tokenLink_should_return_404_if_token_does_not_exist() {
+            given().port(localPort)
+                    .accept(JSON)
+                    .get(String.format("/v1/frontend/auth/%s/123-456", ACCOUNT_ID))
+                    .then()
+                    .statusCode(404);
         }
     
         @Test


### PR DESCRIPTION
Currently the way to revoke an api key is via an [embedded form which contains the token
link](https://github.com/alphagov/pay-selfservice/blob/master/app/views/api-keys/_key.njk#L40-L42) on the API keys (`/account/{accountId}/api-keys`) page on selfservice.

However in the new simplified accounts world the revocation happens on a different page with URL
`/simplified/service/{SERVICE_EXTERNAL_ID}/account/{ACCOUNT_TYPE}/settings/api-keys/revoke/{tokenLink}`. This page shows the text 'Are you sure you want to revoke <api key description/name>?'. We thus need an endpoint in publicauth to get the api key by token link in order to show the key description/name. For security we should pass in the account id too.

