### PR TITLE
PP-13657 upgrade httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <!-- this has been added so we can use org.apache.http.conn.ssl.DefaultHostnameVerifier for Postgres.
+                    publicauth doesn't perform any outgoing HTTP calls -->
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+        </dependency>
 
         <!-- Main dependencies that need explicit versions -->
         <dependency>
@@ -130,13 +136,6 @@
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging-dropwizard-4</artifactId>
             <version>${pay-java-commons.version}</version>
-        </dependency>
-        <dependency>
-        <!-- this has been added so we can use org.apache.http.conn.ssl.DefaultHostnameVerifier for Postgres.
-                it does not work with dropwizard 0.8.x but publicauth doesn't perform any outgoing HTTP calls -->
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
         </dependency>
 
         <!-- Test dependencies that are imported from one of the BOMs specified


### PR DESCRIPTION
## WHAT

Since Dropwizard is using httpclient5, we should also upgrade the client used to connect to PostGreSQL

