### PR TITLE
PP-12364 Add service_mode and service_external_id fields to CreateTokenRequest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -121,6 +121,15 @@
         "line_number": 62
       }
     ],
+    "src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java",
+        "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
     "src/main/java/uk/gov/pay/publicauth/resources/PublicAuthResource.java": [
       {
         "type": "Base64 High Entropy String",
@@ -156,5 +165,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-16T12:00:42Z"
+  "generated_at": "2025-05-16T14:44:17Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": "src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 51
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
@@ -156,5 +156,5 @@
       }
     ]
   },
-  "generated_at": "2024-09-10T09:30:52Z"
+  "generated_at": "2025-05-16T12:00:42Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -119,6 +119,13 @@
         "hashed_secret": "504fdcd9f2dc1213b2f032a7ca2bba4a659ea27a",
         "is_verified": false,
         "line_number": 62
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "openapi/publicauth_spec.yaml",
+        "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
+        "is_verified": false,
+        "line_number": 249
       }
     ],
     "src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java": [
@@ -165,5 +172,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-16T14:44:17Z"
+  "generated_at": "2025-05-16T14:57:41Z"
 }

--- a/openapi/publicauth_spec.yaml
+++ b/openapi/publicauth_spec.yaml
@@ -246,7 +246,7 @@ components:
           example: Token description
         service_external_id:
           type: string
-          example: LIVE
+          example: cd1b871207a94a7fa157dee678146acd
           writeOnly: true
         service_mode:
           type: string

--- a/openapi/publicauth_spec.yaml
+++ b/openapi/publicauth_spec.yaml
@@ -244,6 +244,17 @@ components:
           type: string
           description: Description of the new token
           example: Token description
+        service_external_id:
+          type: string
+          example: LIVE
+          writeOnly: true
+        service_mode:
+          type: string
+          enum:
+          - LIVE
+          - TEST
+          example: LIVE
+          writeOnly: true
         token_account_type:
           type: string
           default: LIVE

--- a/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
@@ -6,6 +6,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotNull;
 
+import java.io.Serial;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static java.util.UUID.randomUUID;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;
 import static uk.gov.pay.publicauth.model.TokenSource.API;
@@ -28,25 +31,37 @@ public class CreateTokenRequest {
     private final TokenLink tokenLink = TokenLink.of(randomUUID().toString());
     @Schema(hidden = true)
     private final TokenAccountType tokenAccountType;
+    @Schema(hidden = true)
+    private final ServiceMode serviceMode;
+    @Schema(hidden = true)
+    private final String serviceExternalId;
 
     @JsonCreator
-    public CreateTokenRequest(@Schema(example = "1", required = true, description = "Gateway account to associate the new token to")
+    public CreateTokenRequest(@Schema(example = "1", description = "Gateway account to associate the new token to", requiredMode = REQUIRED)
                               @NotNull @JsonProperty("account_id") String accountId,
-                              @Schema(example = "Token description", required = true, description = "Description of the new token")
+                              @Schema(example = "Token description", description = "Description of the new token", requiredMode = REQUIRED)
                               @NotNull @JsonProperty("description") String description,
-                              @Schema(required = true, example = "test@example.org") @NotNull @JsonProperty("created_by") String createdBy,
+                              @Schema(example = "test@example.org", requiredMode = REQUIRED) @NotNull @JsonProperty("created_by") String createdBy,
                               @Schema(example = "CARD", defaultValue = "CARD")
                               @JsonProperty("token_type") TokenPaymentType tokenPaymentType,
                               @Schema(example = "API", defaultValue = "API")
                               @JsonProperty("type") TokenSource tokenSource,
                               @Schema(example = "LIVE", defaultValue = "LIVE")
-                              @JsonProperty("token_account_type") TokenAccountType tokenAccountType) {
+                              @JsonProperty("token_account_type") TokenAccountType tokenAccountType,
+                              @Schema(example = "LIVE")
+                              @JsonProperty("service_mode") ServiceMode serviceMode,
+                              @Schema(example = "LIVE") 
+                              @JsonProperty("service_external_id") String serviceExternalId
+        
+    ) {
         this.accountId = accountId;
         this.description = description;
         this.createdBy = createdBy;
         this.tokenPaymentType = tokenPaymentType == null ? CARD : tokenPaymentType;
         this.tokenSource = tokenSource == null ? API : tokenSource;
         this.tokenAccountType = tokenAccountType;
+        this.serviceMode = serviceMode;
+        this.serviceExternalId = serviceExternalId;
     }
 
     public String getAccountId() {
@@ -75,5 +90,13 @@ public class CreateTokenRequest {
 
     public TokenAccountType getTokenAccountType() {
         return tokenAccountType;
+    }
+    
+    public ServiceMode getServiceMode() {
+        return serviceMode;
+    }
+    
+    public String getServiceExternalId() {
+        return serviceExternalId;
     }
 }

--- a/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotNull;
 
-import java.io.Serial;
-
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static java.util.UUID.randomUUID;
 import static uk.gov.pay.publicauth.model.TokenPaymentType.CARD;

--- a/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
@@ -48,7 +48,7 @@ public class CreateTokenRequest {
                               @JsonProperty("token_account_type") TokenAccountType tokenAccountType,
                               @Schema(example = "LIVE")
                               @JsonProperty("service_mode") ServiceMode serviceMode,
-                              @Schema(example = "LIVE") 
+                              @Schema(example = "cd1b871207a94a7fa157dee678146acd")
                               @JsonProperty("service_external_id") String serviceExternalId
         
     ) {

--- a/src/main/java/uk/gov/pay/publicauth/model/ServiceMode.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/ServiceMode.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.publicauth.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum ServiceMode {
+    LIVE, TEST;
+
+    @JsonCreator
+    public static ServiceMode fromString(String type) {
+        return ServiceMode.valueOf(type.toUpperCase());
+    }
+}

--- a/src/main/java/uk/gov/pay/publicauth/model/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/TokenEntity.java
@@ -3,7 +3,6 @@ package uk.gov.pay.publicauth.model;
 import java.time.ZonedDateTime;
 
 public class TokenEntity {
-
     private final TokenLink tokenLink;
     private final String description;
     private final String accountId;
@@ -13,6 +12,8 @@ public class TokenEntity {
     private final ZonedDateTime issuedDate;
     private final ZonedDateTime lastUsedDate;
     private final String createdBy;
+    private final ServiceMode serviceMode;
+    private final String serviceExternalId;
 
     public TokenEntity(TokenLink tokenLink,
                        String description,
@@ -22,7 +23,10 @@ public class TokenEntity {
                        ZonedDateTime revokedDate,
                        ZonedDateTime issuedDate,
                        ZonedDateTime lastUsedDate,
-                       String createdBy) {
+                       String createdBy,
+                       ServiceMode serviceMode,
+                       String serviceExternalId
+    ) {
         this.tokenLink = tokenLink;
         this.description = description;
         this.accountId = accountId;
@@ -32,6 +36,8 @@ public class TokenEntity {
         this.issuedDate = issuedDate;
         this.lastUsedDate = lastUsedDate;
         this.createdBy = createdBy;
+        this.serviceMode = serviceMode;
+        this.serviceExternalId = serviceExternalId;
     }
 
     public TokenEntity(Builder builder) {
@@ -44,6 +50,8 @@ public class TokenEntity {
         this.issuedDate = builder.issuedDate;
         this.lastUsedDate = builder.lastUsedDate;
         this.createdBy = builder.createdBy;
+        this.serviceMode = builder.serviceMode;
+        this.serviceExternalId = builder.serviceExternalId;
     }
 
     public TokenLink getTokenLink() {
@@ -82,6 +90,14 @@ public class TokenEntity {
         return createdBy;
     }
 
+    public ServiceMode getServiceMode() {
+        return serviceMode;
+    }
+
+    public String getServiceExternalId() {
+        return serviceExternalId;
+    }
+
     public static final class Builder {
         private TokenLink tokenLink;
         private String description;
@@ -92,6 +108,8 @@ public class TokenEntity {
         private ZonedDateTime issuedDate;
         private ZonedDateTime lastUsedDate;
         private String createdBy;
+        private ServiceMode serviceMode;
+        private String serviceExternalId;
 
         public Builder() {
             /* empty */
@@ -139,6 +157,16 @@ public class TokenEntity {
 
         public Builder withCreatedBy(String createdBy) {
             this.createdBy = createdBy;
+            return this;
+        }
+        
+        public Builder withServiceMode(ServiceMode serviceMode) {
+            this.serviceMode = serviceMode;
+            return this;
+        }
+
+        public Builder withServiceExternalId(String serviceExternalId) {
+            this.serviceExternalId = serviceExternalId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/publicauth/fixture/TokenEntityFixture.java
+++ b/src/test/java/uk/gov/pay/publicauth/fixture/TokenEntityFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.publicauth.fixture;
 
+import uk.gov.pay.publicauth.model.ServiceMode;
 import uk.gov.pay.publicauth.model.TokenEntity;
 import uk.gov.pay.publicauth.model.TokenLink;
 import uk.gov.pay.publicauth.model.TokenPaymentType;
@@ -20,6 +21,8 @@ public class TokenEntityFixture {
     private ZonedDateTime issuedDate = ZonedDateTime.parse("2020-01-01T12:30:00.000Z");
     private ZonedDateTime lastUsedDate;
     private String createdBy = "a-user-id";
+    private ServiceMode serviceMode;
+    private String serviceExternalId;
 
     private TokenEntityFixture() {
     }
@@ -83,6 +86,9 @@ public class TokenEntityFixture {
                 this.revokedDate,
                 this.issuedDate,
                 this.lastUsedDate,
-                this.createdBy);
+                this.createdBy,
+                this.serviceMode,
+                this.serviceExternalId
+        );
     }
 }

--- a/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
+++ b/src/test/java/uk/gov/pay/publicauth/service/TokenServiceTest.java
@@ -18,6 +18,7 @@ import uk.gov.pay.publicauth.exception.TokenInvalidException;
 import uk.gov.pay.publicauth.exception.TokenRevokedException;
 import uk.gov.pay.publicauth.model.AuthResponse;
 import uk.gov.pay.publicauth.model.CreateTokenRequest;
+import uk.gov.pay.publicauth.model.ServiceMode;
 import uk.gov.pay.publicauth.model.TokenEntity;
 import uk.gov.pay.publicauth.model.TokenHash;
 import uk.gov.pay.publicauth.model.TokenLink;
@@ -50,6 +51,7 @@ class TokenServiceTest {
     private static final String EXPECTED_SECRET_KEY = "qwer9yuhgf";
     private static final List<Character> BASE32_HEX_DICTIONARY = asList("0123456789abcdefghijklmnopqrstuv".toCharArray());
     private static final TokenHash TOKEN_HASH = TokenHash.of("TOKEN");
+    private static final String SERVICE_EXTERNAL_ID = "cd1b871207a94a7fa157dee678146acd";
 
     private TokenService tokenService;
 
@@ -105,7 +107,7 @@ class TokenServiceTest {
 
     @Test
     void shouldCreateValidToken() {
-        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, null);
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, null, ServiceMode.LIVE, SERVICE_EXTERNAL_ID);
         String apiKey = tokenService.createTokenForAccount(createTokenRequest);
 
         // Minimum length guarantee is 32 for Hmac and an extremely very unlikely
@@ -137,21 +139,21 @@ class TokenServiceTest {
 
     @Test
     void shouldCreateValidToken_withPrefixForLiveAccountType() {
-        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.LIVE);
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.LIVE, ServiceMode.LIVE, SERVICE_EXTERNAL_ID);
         String apiKey = tokenService.createTokenForAccount(createTokenRequest);
         assertThat(apiKey.contains("api_live_"), is(true));
     }
 
     @Test
     void shouldCreateValidToken_withPrefixForTestAccountType() {
-        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.TEST);
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.TEST, ServiceMode.TEST, SERVICE_EXTERNAL_ID);
         String apiKey = tokenService.createTokenForAccount(createTokenRequest);
         assertThat(apiKey.contains("api_test_"), is(true));
     }
 
     @Test
     void shouldCreateDifferentTokensWhenCalledTwice() {
-        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.LIVE);
+        CreateTokenRequest createTokenRequest = new CreateTokenRequest("42", "A token description", "a-user-id", CARD, API, TokenAccountType.LIVE, ServiceMode.LIVE, SERVICE_EXTERNAL_ID);
         String apiKey1 = tokenService.createTokenForAccount(createTokenRequest);
         String apiKey2 = tokenService.createTokenForAccount(createTokenRequest);
 

--- a/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/publicauth/utils/DatabaseTestHelper.java
@@ -70,7 +70,7 @@ public class DatabaseTestHelper {
 
     public Map<String, Object> getTokenByHash(TokenHash tokenHash) {
         return jdbi.withHandle(h ->
-                h.createQuery("SELECT token_id, type, token_type, token_hash, account_id, issued, revoked, token_link, description, created_by " +
+                h.createQuery("SELECT token_id, type, token_type, token_hash, account_id, issued, revoked, token_link, description, created_by, service_mode, service_external_id " +
                                 "FROM tokens t " +
                                 "WHERE token_hash = :token_hash")
                         .bind("token_hash", tokenHash.getValue())


### PR DESCRIPTION
## WHAT
 - add `service_mode` and `service_external_id` as optional fields to `CreateTokenRequest`
 - add tests that these fields are saved to the database
 - update deprecated `required = true` parameter in Swagger `Schema` annotations
