### PR TITLE
PP-14240 Make service_external_id and service_mode required when creating tokens

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,7 +150,7 @@
         "filename": "src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java",
         "hashed_secret": "4e2117d267bb6ba687414034ca6f7699e03d0098",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 53
       }
     ],
     "src/main/java/uk/gov/pay/publicauth/model/TokenResponse.java": [

--- a/openapi/publicauth_spec.yaml
+++ b/openapi/publicauth_spec.yaml
@@ -445,6 +445,8 @@ components:
       - account_id
       - created_by
       - description
+      - service_external_id
+      - service_mode
     JsonNode:
       type: object
     TokenResponse:

--- a/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
+++ b/src/main/java/uk/gov/pay/publicauth/model/CreateTokenRequest.java
@@ -30,8 +30,10 @@ public class CreateTokenRequest {
     @Schema(hidden = true)
     private final TokenAccountType tokenAccountType;
     @Schema(hidden = true)
+    @NotNull
     private final ServiceMode serviceMode;
     @Schema(hidden = true)
+    @NotNull
     private final String serviceExternalId;
 
     @JsonCreator
@@ -46,9 +48,9 @@ public class CreateTokenRequest {
                               @JsonProperty("type") TokenSource tokenSource,
                               @Schema(example = "LIVE", defaultValue = "LIVE")
                               @JsonProperty("token_account_type") TokenAccountType tokenAccountType,
-                              @Schema(example = "LIVE")
+                              @Schema(example = "LIVE", requiredMode = REQUIRED)
                               @JsonProperty("service_mode") ServiceMode serviceMode,
-                              @Schema(example = "cd1b871207a94a7fa157dee678146acd")
+                              @Schema(example = "cd1b871207a94a7fa157dee678146acd", requiredMode = REQUIRED)
                               @JsonProperty("service_external_id") String serviceExternalId
         
     ) {

--- a/src/test/java/uk/gov/pay/publicauth/it/PublicAuthRevokeTokenResourceIT.java
+++ b/src/test/java/uk/gov/pay/publicauth/it/PublicAuthRevokeTokenResourceIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.publicauth.model.ServiceMode;
 import uk.gov.pay.publicauth.service.TokenService;
 import uk.gov.pay.publicauth.utils.DropwizardAppWithPostgresExtension;
 
@@ -32,6 +33,8 @@ public class PublicAuthRevokeTokenResourceIT {
     private Integer applicationPort;
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+    private static final ServiceMode SERVICE_MODE = ServiceMode.TEST;
+    private static final String SERVICE_EXTERNAL_ID = "cd1b871207a94a7fa157dee678146acd";
 
     @BeforeEach
     public void setup(Integer port) {
@@ -45,20 +48,32 @@ public class PublicAuthRevokeTokenResourceIT {
     public void revokeAllTokensForAnAccountSuccessfully() {
         String accountId = "1";
         
-        Map<String, String> token1 = Map.of("account_id", accountId,
+        Map<String, String> token1 = Map.of(
+                "account_id", accountId,
                 "description", "Bellatrix's token",
                 "token_account_type", "live",
-                "created_by", "bellatrix@lestrange.hp");
+                "created_by", "bellatrix@lestrange.hp",
+                "service_external_id", SERVICE_EXTERNAL_ID,
+                "service_mode", SERVICE_MODE.toString()
+        );
         
-        Map<String, String> token2 = Map.of("account_id", accountId,
+        Map<String, String> token2 = Map.of(
+                "account_id", accountId,
                 "description", "Sirius's token",
                 "token_account_type", "test",
-                "created_by", "sirius@black.hp");
+                "created_by", "sirius@black.hp",
+                "service_external_id", SERVICE_EXTERNAL_ID,
+                "service_mode", SERVICE_MODE.toString()
+        );
 
-        Map<String, String> token3 = Map.of("account_id", "2",
+        Map<String, String> token3 = Map.of(
+                "account_id", "2",
                 "description", "Buckbeak's token",
                 "token_account_type", "test",
-                "created_by", "buck@beak.hp");
+                "created_by", "buck@beak.hp",
+                "service_external_id", SERVICE_EXTERNAL_ID,
+                "service_mode", SERVICE_MODE.toString()
+        );
         
         createToken(token1);
         createToken(token2);


### PR DESCRIPTION
## WHAT
 - add `NotNull` constraint to `service_mode` and `service_external_id` on `CreateTokenRequest`


