### PR TITLE
PP-14046 Set new columns in the tokens table to non-nullable in the public auth database schema

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -165,5 +165,10 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="set service_mode and service_external_id as non-nullable" author="">
+        <addNotNullConstraint tableName="tokens" columnName="service_mode"/>
+        <addNotNullConstraint tableName="tokens" columnName="service_external_id"/>
+    </changeSet>
+
 
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
- add db migration that sets columns `service_mode` and `service_external_id` in tokens table as non-nullable



