### PR TITLE
PP-14349 remove dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
       interval: daily
       time: "03:00"
     ignore:
-      - dependency-name: "io.dropwizard:dropwizard-dependencies"
-        # Dropwizard 4.x only works with Jakarta EE and not Java EE
-        versions:
-          - ">= 4"
       - dependency-name: "org.dhatim:dropwizard-sentry"
         # We essentially forked Dropwizard Sentry because it did not support
         # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports


### PR DESCRIPTION
## WHAT

Forgot to remove the ignore entry for `io.dropwizard:dropwizard-dependencies` when upgrading to Dropwizard 4.

Remove the unwanted ignore entry fromn the config file.

